### PR TITLE
use all optional model to improve code quality / readability

### DIFF
--- a/src/antares/model/area.py
+++ b/src/antares/model/area.py
@@ -113,6 +113,11 @@ class AreaPropertiesLocal(NonOptionalAreaProperties, alias_generator=config_alia
     def adequacy_patch(self) -> dict[str, dict[str, str]]:
         return {"adequacy-patch": {"adequacy-patch-mode": self.adequacy_patch_mode.value}}
 
+    def yield_local_dict(self) -> dict[str, Mapping[str, str]]:
+        args = {"nodal optimization": self.nodal_optimization}
+        args.update({"filtering": self.filtering})
+        return args
+
     def yield_area_properties(self) -> AreaProperties:
         excludes = {"filtering", "nodal_optimization"}
         return AreaProperties.model_validate(self.model_dump(mode="json", exclude=excludes))

--- a/src/antares/model/area.py
+++ b/src/antares/model/area.py
@@ -33,6 +33,7 @@ from antares.model.solar import Solar
 from antares.model.st_storage import STStorage, STStorageProperties
 from antares.model.thermal import ThermalCluster, ThermalClusterProperties
 from antares.model.wind import Wind
+from antares.tools.all_optional_meta import all_optional_model
 from antares.tools.contents_tool import transform_name_to_id, EnumIgnoreCase
 
 
@@ -48,111 +49,73 @@ class AdequacyPatchMode(EnumIgnoreCase):
     VIRTUAL = "virtual"
 
 
-# todo: Warning, with filesystem, we want to avoid camel case and use link_aliasing.
-class AreaProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
+class NonOptionalAreaProperties(BaseModel, extra="forbid", populate_by_name=True):
     """
     DTO for updating area properties
     """
 
-    energy_cost_unsupplied: Optional[float] = None
-    energy_cost_spilled: Optional[float] = None
-    non_dispatch_power: Optional[bool] = None
-    dispatch_hydro_power: Optional[bool] = None
-    other_dispatch_power: Optional[bool] = None
-    filter_synthesis: Optional[Set[FilterOption]] = None
-    filter_by_year: Optional[Set[FilterOption]] = None
+    energy_cost_unsupplied: float = 0.0
+    energy_cost_spilled: float = 0.0
+    non_dispatch_power: bool = True
+    dispatch_hydro_power: bool = True
+    other_dispatch_power: bool = True
+    filter_synthesis: Set[FilterOption] = {
+        FilterOption.HOURLY,
+        FilterOption.DAILY,
+        FilterOption.WEEKLY,
+        FilterOption.MONTHLY,
+        FilterOption.ANNUAL,
+    }
+    filter_by_year: Set[FilterOption] = {
+        FilterOption.HOURLY,
+        FilterOption.DAILY,
+        FilterOption.WEEKLY,
+        FilterOption.MONTHLY,
+        FilterOption.ANNUAL,
+    }
     # version 830
-    adequacy_patch_mode: Optional[AdequacyPatchMode] = None
-    spread_unsupplied_energy_cost: Optional[float] = None
-    spread_spilled_energy_cost: Optional[float] = None
+    adequacy_patch_mode: AdequacyPatchMode = AdequacyPatchMode.OUTSIDE
+    spread_unsupplied_energy_cost: float = 0.0
+    spread_spilled_energy_cost: float = 0.0
+
+
+@all_optional_model
+class AreaProperties(NonOptionalAreaProperties, alias_generator=to_camel):
+    pass
 
 
 def config_alias_generator(field_name: str) -> str:
     return field_name.replace("_", " ")
 
 
-# TODO update to use check_if_none
-class AreaPropertiesLocal(BaseModel, alias_generator=config_alias_generator):
-    def __init__(
-        self,
-        input_area_properties: AreaProperties = AreaProperties(),
-        **kwargs: Optional[Any],
-    ):
-        super().__init__(**kwargs)
-        self._energy_cost_unsupplied = input_area_properties.energy_cost_unsupplied or 0.0
-        self._energy_cost_spilled = input_area_properties.energy_cost_spilled or 0.0
-        self._non_dispatch_power = (
-            input_area_properties.non_dispatch_power if input_area_properties.non_dispatch_power is not None else True
-        )
-        self._dispatch_hydro_power = (
-            input_area_properties.dispatch_hydro_power
-            if input_area_properties.dispatch_hydro_power is not None
-            else True
-        )
-        self._other_dispatch_power = (
-            input_area_properties.other_dispatch_power
-            if input_area_properties.other_dispatch_power is not None
-            else True
-        )
-        self._filter_synthesis = input_area_properties.filter_synthesis or {
-            FilterOption.HOURLY,
-            FilterOption.DAILY,
-            FilterOption.WEEKLY,
-            FilterOption.MONTHLY,
-            FilterOption.ANNUAL,
-        }
-        self._filter_by_year = input_area_properties.filter_by_year or {
-            FilterOption.HOURLY,
-            FilterOption.DAILY,
-            FilterOption.WEEKLY,
-            FilterOption.MONTHLY,
-            FilterOption.ANNUAL,
-        }
-        self._adequacy_patch_mode = (
-            input_area_properties.adequacy_patch_mode
-            if input_area_properties.adequacy_patch_mode
-            else AdequacyPatchMode.OUTSIDE
-        )
-        self._spread_spilled_energy_cost = input_area_properties.spread_spilled_energy_cost or 0.0
-        self._spread_unsupplied_energy_cost = input_area_properties.spread_unsupplied_energy_cost or 0.0
-
+class AreaPropertiesLocal(NonOptionalAreaProperties, alias_generator=config_alias_generator):
     @computed_field  # type: ignore[misc]
     @property
     def nodal_optimization(self) -> Mapping[str, str]:
         return {
-            "non-dispatchable-power": f"{self._non_dispatch_power}".lower(),
-            "dispatchable-hydro-power": f"{self._dispatch_hydro_power}".lower(),
-            "other-dispatchable-power": f"{self._other_dispatch_power}".lower(),
-            "spread-unsupplied-energy-cost": f"{self._spread_unsupplied_energy_cost:.6f}",
-            "spread-spilled-energy-cost": f"{self._spread_spilled_energy_cost:.6f}",
-            "average-unsupplied-energy-cost": f"{self._energy_cost_unsupplied:.6f}",
-            "average-spilled-energy-cost": f"{self._energy_cost_spilled:.6f}",
+            "non-dispatchable-power": f"{self.non_dispatch_power}".lower(),
+            "dispatchable-hydro-power": f"{self.dispatch_hydro_power}".lower(),
+            "other-dispatchable-power": f"{self.other_dispatch_power}".lower(),
+            "spread-unsupplied-energy-cost": f"{self.spread_unsupplied_energy_cost:.6f}",
+            "spread-spilled-energy-cost": f"{self.spread_spilled_energy_cost:.6f}",
+            "average-unsupplied-energy-cost": f"{self.energy_cost_unsupplied:.6f}",
+            "average-spilled-energy-cost": f"{self.energy_cost_spilled:.6f}",
         }
 
     @computed_field  # type: ignore[misc]
     @property
     def filtering(self) -> Mapping[str, str]:
         return {
-            "filter-synthesis": ", ".join(filter_value for filter_value in sort_filter_values(self._filter_synthesis)),
-            "filter-year-by-year": ", ".join(filter_value for filter_value in sort_filter_values(self._filter_by_year)),
+            "filter-synthesis": ", ".join(filter_value for filter_value in sort_filter_values(self.filter_synthesis)),
+            "filter-year-by-year": ", ".join(filter_value for filter_value in sort_filter_values(self.filter_by_year)),
         }
 
-    def adequacy_patch_mode(self) -> dict[str, dict[str, str]]:
-        return {"adequacy-patch": {"adequacy-patch-mode": self._adequacy_patch_mode.value}}
+    def adequacy_patch(self) -> dict[str, dict[str, str]]:
+        return {"adequacy-patch": {"adequacy-patch-mode": self.adequacy_patch_mode.value}}
 
     def yield_area_properties(self) -> AreaProperties:
-        return AreaProperties(
-            energy_cost_unsupplied=self._energy_cost_unsupplied,
-            energy_cost_spilled=self._energy_cost_spilled,
-            non_dispatch_power=self._non_dispatch_power,
-            dispatch_hydro_power=self._dispatch_hydro_power,
-            other_dispatch_power=self._other_dispatch_power,
-            filter_synthesis=self._filter_synthesis,
-            filter_by_year=self._filter_by_year,
-            adequacy_patch_mode=self._adequacy_patch_mode,
-            spread_unsupplied_energy_cost=self._spread_unsupplied_energy_cost,
-            spread_spilled_energy_cost=self._spread_spilled_energy_cost,
-        )
+        excludes = {"filtering", "nodal_optimization"}
+        return AreaProperties.model_validate(self.model_dump(mode="json", exclude=excludes))
 
 
 class AreaUi(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):

--- a/src/antares/model/area.py
+++ b/src/antares/model/area.py
@@ -49,7 +49,7 @@ class AdequacyPatchMode(EnumIgnoreCase):
     VIRTUAL = "virtual"
 
 
-class NonOptionalAreaProperties(BaseModel, extra="forbid", populate_by_name=True):
+class DefaultAreaProperties(BaseModel, extra="forbid", populate_by_name=True):
     """
     DTO for updating area properties
     """
@@ -80,7 +80,7 @@ class NonOptionalAreaProperties(BaseModel, extra="forbid", populate_by_name=True
 
 
 @all_optional_model
-class AreaProperties(NonOptionalAreaProperties, alias_generator=to_camel):
+class AreaProperties(DefaultAreaProperties, alias_generator=to_camel):
     pass
 
 
@@ -88,7 +88,7 @@ def config_alias_generator(field_name: str) -> str:
     return field_name.replace("_", " ")
 
 
-class AreaPropertiesLocal(NonOptionalAreaProperties, alias_generator=config_alias_generator):
+class AreaPropertiesLocal(DefaultAreaProperties, alias_generator=config_alias_generator):
     @computed_field  # type: ignore[misc]
     @property
     def nodal_optimization(self) -> Mapping[str, str]:

--- a/src/antares/model/cluster.py
+++ b/src/antares/model/cluster.py
@@ -24,19 +24,15 @@ class ClusterProperties(BaseModel, extra="forbid", populate_by_name=True, alias_
     # Activity status:
     # - True: the plant may generate.
     # - False: not yet commissioned, moth-balled, etc.
-    enabled: Optional[bool] = None
+    enabled: bool = True
 
-    unit_count: Optional[int] = None
-    nominal_capacity: Optional[float] = None
+    unit_count: int = 1
+    nominal_capacity: float = 0
 
     @property
-    def installed_capacity(self) -> Optional[float]:
-        if self.unit_count is None or self.nominal_capacity is None:
-            return None
+    def installed_capacity(self) -> float:
         return self.unit_count * self.nominal_capacity
 
     @property
     def enabled_capacity(self) -> Optional[float]:
-        if self.enabled is None or self.installed_capacity is None:
-            return None
         return self.enabled * self.installed_capacity

--- a/src/antares/model/cluster.py
+++ b/src/antares/model/cluster.py
@@ -30,9 +30,13 @@ class ClusterProperties(BaseModel, extra="forbid", populate_by_name=True, alias_
     nominal_capacity: float = 0
 
     @property
-    def installed_capacity(self) -> float:
+    def installed_capacity(self) -> Optional[float]:
+        if self.unit_count is None or self.nominal_capacity is None:
+            return None
         return self.unit_count * self.nominal_capacity
 
     @property
     def enabled_capacity(self) -> Optional[float]:
+        if self.enabled is None or self.installed_capacity is None:
+            return None
         return self.enabled * self.installed_capacity

--- a/src/antares/model/hydro.py
+++ b/src/antares/model/hydro.py
@@ -32,7 +32,7 @@ class HydroMatrixName(Enum):
     COMMON_CREDIT_MODULATIONS = "creditmodulations"
 
 
-class NonOptionalHydroProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
+class DefaultHydroProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
     """
     Properties of hydro system read from the configuration files.
 
@@ -57,11 +57,11 @@ class NonOptionalHydroProperties(BaseModel, extra="forbid", populate_by_name=Tru
 
 
 @all_optional_model
-class HydroProperties(NonOptionalHydroProperties):
+class HydroProperties(DefaultHydroProperties):
     pass
 
 
-class HydroPropertiesLocal(NonOptionalHydroProperties):
+class HydroPropertiesLocal(DefaultHydroProperties):
     area_id: str
 
     @computed_field  # type: ignore[misc]

--- a/src/antares/model/hydro.py
+++ b/src/antares/model/hydro.py
@@ -11,13 +11,13 @@
 # This file is part of the Antares project.
 
 from enum import Enum
-from typing import Optional, Dict, Any
+from typing import Optional, Dict
 
 import pandas as pd
 from pydantic import BaseModel, computed_field
 from pydantic.alias_generators import to_camel
 
-from antares.tools.ini_tool import check_if_none
+from antares.tools.all_optional_meta import all_optional_model
 
 
 class HydroMatrixName(Enum):
@@ -32,95 +32,62 @@ class HydroMatrixName(Enum):
     COMMON_CREDIT_MODULATIONS = "creditmodulations"
 
 
-class HydroProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
+class NonOptionalHydroProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
     """
     Properties of hydro system read from the configuration files.
 
     All aliases match the name of the corresponding field in the INI files.
     """
 
-    inter_daily_breakdown: Optional[float] = None
-    intra_daily_modulation: Optional[float] = None
-    inter_monthly_breakdown: Optional[float] = None
-    reservoir: Optional[bool] = None
-    reservoir_capacity: Optional[float] = None
-    follow_load: Optional[bool] = None
-    use_water: Optional[bool] = None
-    hard_bounds: Optional[bool] = None
-    initialize_reservoir_date: Optional[int] = None
-    use_heuristic: Optional[bool] = None
-    power_to_level: Optional[bool] = None
-    use_leeway: Optional[bool] = None
-    leeway_low: Optional[float] = None
-    leeway_up: Optional[float] = None
-    pumping_efficiency: Optional[float] = None
+    inter_daily_breakdown: float = 1
+    intra_daily_modulation: float = 24
+    inter_monthly_breakdown: float = 1
+    reservoir: bool = False
+    reservoir_capacity: float = 0
+    follow_load: bool = True
+    use_water: bool = False
+    hard_bounds: bool = False
+    initialize_reservoir_date: int = 0
+    use_heuristic: bool = True
+    power_to_level: bool = False
+    use_leeway: bool = False
+    leeway_low: float = 1
+    leeway_up: float = 1
+    pumping_efficiency: float = 1
 
 
-class HydroPropertiesLocal(BaseModel):
-    def __init__(
-        self,
-        area_id: str,
-        hydro_properties: Optional[HydroProperties] = None,
-        **kwargs: Optional[Any],
-    ):
-        super().__init__(**kwargs)
-        self._area_id = area_id
-        hydro_properties = hydro_properties or HydroProperties()
-        self._inter_daily_breakdown = check_if_none(hydro_properties.inter_daily_breakdown, 1)
-        self._intra_daily_modulation = check_if_none(hydro_properties.intra_daily_modulation, 24)
-        self._inter_monthly_breakdown = check_if_none(hydro_properties.inter_monthly_breakdown, 1)
-        self._reservoir = check_if_none(hydro_properties.reservoir, False)
-        self._reservoir_capacity = check_if_none(hydro_properties.reservoir_capacity, 0)
-        self._follow_load = check_if_none(hydro_properties.follow_load, True)
-        self._use_water = check_if_none(hydro_properties.use_water, False)
-        self._hard_bounds = check_if_none(hydro_properties.hard_bounds, False)
-        self._initialize_reservoir_date = check_if_none(hydro_properties.initialize_reservoir_date, 0)
-        self._use_heuristic = check_if_none(hydro_properties.use_heuristic, True)
-        self._power_to_level = check_if_none(hydro_properties.power_to_level, False)
-        self._use_leeway = check_if_none(hydro_properties.use_leeway, False)
-        self._leeway_low = check_if_none(hydro_properties.leeway_low, 1)
-        self._leeway_up = check_if_none(hydro_properties.leeway_up, 1)
-        self._pumping_efficiency = check_if_none(hydro_properties.pumping_efficiency, 1)
+@all_optional_model
+class HydroProperties(NonOptionalHydroProperties):
+    pass
+
+
+class HydroPropertiesLocal(NonOptionalHydroProperties):
+    area_id: str
 
     @computed_field  # type: ignore[misc]
     @property
     def hydro_ini_fields(self) -> dict[str, dict[str, str]]:
         return {
-            "inter-daily-breakdown": {f"{self._area_id}": f"{self._inter_daily_breakdown:.6f}"},
-            "intra-daily-modulation": {f"{self._area_id}": f"{self._intra_daily_modulation:.6f}"},
-            "inter-monthly-breakdown": {f"{self._area_id}": f"{self._inter_monthly_breakdown:.6f}"},
-            "reservoir": {f"{self._area_id}": f"{self._reservoir}".lower()},
-            "reservoir capacity": {f"{self._area_id}": f"{self._reservoir_capacity:.6f}"},
-            "follow load": {f"{self._area_id}": f"{self._follow_load}".lower()},
-            "use water": {f"{self._area_id}": f"{self._use_water}".lower()},
-            "hard bounds": {f"{self._area_id}": f"{self._hard_bounds}".lower()},
-            "initialize reservoir date": {f"{self._area_id}": f"{self._initialize_reservoir_date}"},
-            "use heuristic": {f"{self._area_id}": f"{self._use_heuristic}".lower()},
-            "power to level": {f"{self._area_id}": f"{self._power_to_level}".lower()},
-            "use leeway": {f"{self._area_id}": f"{self._use_leeway}".lower()},
-            "leeway low": {f"{self._area_id}": f"{self._leeway_low:.6f}"},
-            "leeway up": {f"{self._area_id}": f"{self._leeway_up:.6f}"},
-            "pumping efficiency": {f"{self._area_id}": f"{self._pumping_efficiency:.6f}"},
+            "inter-daily-breakdown": {f"{self.area_id}": f"{self.inter_daily_breakdown:.6f}"},
+            "intra-daily-modulation": {f"{self.area_id}": f"{self.intra_daily_modulation:.6f}"},
+            "inter-monthly-breakdown": {f"{self.area_id}": f"{self.inter_monthly_breakdown:.6f}"},
+            "reservoir": {f"{self.area_id}": f"{self.reservoir}".lower()},
+            "reservoir capacity": {f"{self.area_id}": f"{self.reservoir_capacity:.6f}"},
+            "follow load": {f"{self.area_id}": f"{self.follow_load}".lower()},
+            "use water": {f"{self.area_id}": f"{self.use_water}".lower()},
+            "hard bounds": {f"{self.area_id}": f"{self.hard_bounds}".lower()},
+            "initialize reservoir date": {f"{self.area_id}": f"{self.initialize_reservoir_date}"},
+            "use heuristic": {f"{self.area_id}": f"{self.use_heuristic}".lower()},
+            "power to level": {f"{self.area_id}": f"{self.power_to_level}".lower()},
+            "use leeway": {f"{self.area_id}": f"{self.use_leeway}".lower()},
+            "leeway low": {f"{self.area_id}": f"{self.leeway_low:.6f}"},
+            "leeway up": {f"{self.area_id}": f"{self.leeway_up:.6f}"},
+            "pumping efficiency": {f"{self.area_id}": f"{self.pumping_efficiency:.6f}"},
         }
 
     def yield_hydro_properties(self) -> HydroProperties:
-        return HydroProperties(
-            inter_daily_breakdown=self._inter_daily_breakdown,
-            intra_daily_modulation=self._intra_daily_modulation,
-            inter_monthly_breakdown=self._inter_monthly_breakdown,
-            reservoir=self._reservoir,
-            reservoir_capacity=self._reservoir_capacity,
-            follow_load=self._follow_load,
-            use_water=self._use_water,
-            hard_bounds=self._hard_bounds,
-            initialize_reservoir_date=self._initialize_reservoir_date,
-            use_heuristic=self._use_heuristic,
-            power_to_level=self._power_to_level,
-            use_leeway=self._use_leeway,
-            leeway_low=self._leeway_low,
-            leeway_up=self._leeway_up,
-            pumping_efficiency=self._pumping_efficiency,
-        )
+        excludes = {"area_id", "hydro_ini_fields"}
+        return HydroProperties.model_validate(self.model_dump(mode="json", exclude=excludes))
 
 
 class Hydro:

--- a/src/antares/model/link.py
+++ b/src/antares/model/link.py
@@ -45,7 +45,7 @@ def link_aliasing(string: str) -> str:
     return string.replace("_", "-")
 
 
-class NonOptionalLinkProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=link_aliasing):
+class DefaultLinkProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=link_aliasing):
     """
     DTO for updating link properties
     """
@@ -73,11 +73,11 @@ class NonOptionalLinkProperties(BaseModel, extra="forbid", populate_by_name=True
 
 
 @all_optional_model
-class LinkProperties(NonOptionalLinkProperties):
+class LinkProperties(DefaultLinkProperties):
     pass
 
 
-class LinkPropertiesLocal(NonOptionalLinkProperties):
+class LinkPropertiesLocal(DefaultLinkProperties):
     @computed_field  # type: ignore[misc]
     @property
     def ini_fields(self) -> Mapping[str, str]:
@@ -99,7 +99,7 @@ class LinkPropertiesLocal(NonOptionalLinkProperties):
         return LinkProperties.model_validate(self.model_dump(mode="json", exclude=excludes))
 
 
-class NonOptionalLinkUi(BaseModel, extra="forbid", populate_by_name=True, alias_generator=link_aliasing):
+class DefaultLinkUi(BaseModel, extra="forbid", populate_by_name=True, alias_generator=link_aliasing):
     """
     DTO for updating link UI
     """
@@ -112,11 +112,11 @@ class NonOptionalLinkUi(BaseModel, extra="forbid", populate_by_name=True, alias_
 
 
 @all_optional_model
-class LinkUi(NonOptionalLinkUi):
+class LinkUi(DefaultLinkUi):
     pass
 
 
-class LinkUiLocal(NonOptionalLinkUi):
+class LinkUiLocal(DefaultLinkUi):
     @computed_field  # type: ignore[misc]
     @property
     def ini_fields(self) -> Mapping[str, str]:

--- a/src/antares/model/renewable.py
+++ b/src/antares/model/renewable.py
@@ -55,7 +55,7 @@ class TimeSeriesInterpretation(Enum):
     PRODUCTION_FACTOR = "production-factor"
 
 
-class NonOptionalRenewableClusterProperties(ClusterProperties):
+class DefaultRenewableClusterProperties(ClusterProperties):
     """
     Properties of a renewable cluster read from the configuration files.
     """
@@ -65,11 +65,11 @@ class NonOptionalRenewableClusterProperties(ClusterProperties):
 
 
 @all_optional_model
-class RenewableClusterProperties(NonOptionalRenewableClusterProperties):
+class RenewableClusterProperties(DefaultRenewableClusterProperties):
     pass
 
 
-class RenewableClusterPropertiesLocal(NonOptionalRenewableClusterProperties):
+class RenewableClusterPropertiesLocal(DefaultRenewableClusterProperties):
     renewable_name: str
 
     @computed_field  # type: ignore[misc]

--- a/src/antares/model/renewable.py
+++ b/src/antares/model/renewable.py
@@ -11,10 +11,10 @@
 # This file is part of the Antares project.
 
 from enum import Enum
-from typing import Optional, Any
+from typing import Optional
 
 import pandas as pd
-from pydantic import BaseModel, computed_field
+from pydantic import computed_field
 
 from antares.model.cluster import ClusterProperties
 from antares.tools.all_optional_meta import all_optional_model
@@ -69,61 +69,26 @@ class RenewableClusterProperties(NonOptionalRenewableClusterProperties):
     pass
 
 
-# TODO update to use check_if_none
-class RenewableClusterPropertiesLocal(
-    BaseModel,
-):
-    def __init__(
-        self,
-        renewable_name: str,
-        renewable_cluster_properties: Optional[RenewableClusterProperties] = None,
-        **kwargs: Optional[Any],
-    ):
-        super().__init__(**kwargs)
-        renewable_cluster_properties = renewable_cluster_properties or RenewableClusterProperties()
-        self._renewable_name = renewable_name
-        self._enabled = (
-            renewable_cluster_properties.enabled if renewable_cluster_properties.enabled is not None else True
-        )
-        self._unit_count = (
-            renewable_cluster_properties.unit_count if renewable_cluster_properties.unit_count is not None else 1
-        )
-        self._nominal_capacity = (
-            renewable_cluster_properties.nominal_capacity
-            if renewable_cluster_properties.nominal_capacity is not None
-            else 0
-        )
-        self._group = renewable_cluster_properties.group or RenewableClusterGroup.OTHER1
-        self._ts_interpretation = (
-            renewable_cluster_properties.ts_interpretation or TimeSeriesInterpretation.POWER_GENERATION
-        )
-
-    @property
-    def renewable_name(self) -> str:
-        return self._renewable_name
+class RenewableClusterPropertiesLocal(NonOptionalRenewableClusterProperties):
+    renewable_name: str
 
     @computed_field  # type: ignore[misc]
     @property
     def ini_fields(self) -> dict[str, dict[str, str]]:
         return {
-            self._renewable_name: {
-                "name": self._renewable_name,
-                "group": self._group.value,
-                "enabled": f"{self._enabled}".lower(),
-                "nominalcapacity": f"{self._nominal_capacity:.6f}",
-                "unitcount": f"{self._unit_count}",
-                "ts-interpretation": self._ts_interpretation.value,
+            self.renewable_name: {
+                "name": self.renewable_name,
+                "group": self.group.value,
+                "enabled": f"{self.enabled}".lower(),
+                "nominalcapacity": f"{self.nominal_capacity:.6f}",
+                "unitcount": f"{self.unit_count}",
+                "ts-interpretation": self.ts_interpretation.value,
             }
         }
 
     def yield_renewable_cluster_properties(self) -> RenewableClusterProperties:
-        return RenewableClusterProperties(
-            enabled=self._enabled,
-            unit_count=self._unit_count,
-            nominal_capacity=self._nominal_capacity,
-            group=self._group,
-            ts_interpretation=self._ts_interpretation,
-        )
+        excludes = {"renewable_name", "ini_fields"}
+        return RenewableClusterProperties.model_validate(self.model_dump(mode="json", exclude=excludes))
 
 
 class RenewableCluster:

--- a/src/antares/model/renewable.py
+++ b/src/antares/model/renewable.py
@@ -17,6 +17,7 @@ import pandas as pd
 from pydantic import BaseModel, computed_field
 
 from antares.model.cluster import ClusterProperties
+from antares.tools.all_optional_meta import all_optional_model
 from antares.tools.contents_tool import transform_name_to_id
 
 
@@ -54,13 +55,18 @@ class TimeSeriesInterpretation(Enum):
     PRODUCTION_FACTOR = "production-factor"
 
 
-class RenewableClusterProperties(ClusterProperties):
+class NonOptionalRenewableClusterProperties(ClusterProperties):
     """
     Properties of a renewable cluster read from the configuration files.
     """
 
-    group: Optional[RenewableClusterGroup] = None
-    ts_interpretation: Optional[TimeSeriesInterpretation] = None
+    group: RenewableClusterGroup = RenewableClusterGroup.OTHER1
+    ts_interpretation: TimeSeriesInterpretation = TimeSeriesInterpretation.POWER_GENERATION
+
+
+@all_optional_model
+class RenewableClusterProperties(NonOptionalRenewableClusterProperties):
+    pass
 
 
 # TODO update to use check_if_none

--- a/src/antares/model/st_storage.py
+++ b/src/antares/model/st_storage.py
@@ -11,14 +11,14 @@
 # This file is part of the Antares project.
 
 from enum import Enum
-from typing import Optional, Any
+from typing import Optional
 
 import pandas as pd
 from pydantic import BaseModel, computed_field
 from pydantic.alias_generators import to_camel
 
+from antares.tools.all_optional_meta import all_optional_model
 from antares.tools.contents_tool import transform_name_to_id
-from antares.tools.ini_tool import check_if_none
 
 
 class STStorageGroup(Enum):
@@ -42,75 +42,52 @@ class STStorageMatrixName(Enum):
     INFLOWS = "inflows"
 
 
-class STStorageProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
+class NonOptionalSTStorageProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
     """
     Properties of a short-term storage system read from the configuration files.
 
     All aliases match the name of the corresponding field in the INI files.
     """
 
-    group: Optional[STStorageGroup] = None
-    injection_nominal_capacity: Optional[float] = None
-    withdrawal_nominal_capacity: Optional[float] = None
-    reservoir_capacity: Optional[float] = None
-    efficiency: Optional[float] = None
-    initial_level: Optional[float] = None
-    initial_level_optim: Optional[bool] = None
+    group: STStorageGroup = STStorageGroup.OTHER1
+    injection_nominal_capacity: float = 0
+    withdrawal_nominal_capacity: float = 0
+    reservoir_capacity: float = 0
+    efficiency: float = 1
+    initial_level: float = 0.5
+    initial_level_optim: bool = False
     # v880
-    enabled: Optional[bool] = None
+    enabled: bool = True
 
 
-class STStoragePropertiesLocal(BaseModel):
-    def __init__(
-        self,
-        st_storage_name: str,
-        st_storage_properties: Optional[STStorageProperties] = None,
-        **kwargs: Optional[Any],
-    ):
-        super().__init__(**kwargs)
-        st_storage_properties = st_storage_properties or STStorageProperties()
-        self._st_storage_name = st_storage_name
-        self._group = check_if_none(st_storage_properties.group, STStorageGroup.OTHER1)
-        self._injection_nominal_capacity = check_if_none(st_storage_properties.injection_nominal_capacity, 0)
-        self._withdrawal_nominal_capacity = check_if_none(st_storage_properties.withdrawal_nominal_capacity, 0)
-        self._reservoir_capacity = check_if_none(st_storage_properties.reservoir_capacity, 0)
-        self._efficiency = check_if_none(st_storage_properties.efficiency, 1)
-        self._initial_level = check_if_none(st_storage_properties.initial_level, 0.5)
-        self._initial_level_optim = check_if_none(st_storage_properties.initial_level_optim, False)
-        self._enabled = check_if_none(st_storage_properties.enabled, True)
+@all_optional_model
+class STStorageProperties(NonOptionalSTStorageProperties):
+    pass
 
-    @property
-    def st_storage_name(self) -> str:
-        return self._st_storage_name
+
+class STStoragePropertiesLocal(NonOptionalSTStorageProperties):
+    st_storage_name: str
 
     @computed_field  # type: ignore[misc]
     @property
     def list_ini_fields(self) -> dict[str, dict[str, str]]:
         return {
-            f"{self._st_storage_name}": {
-                "name": self._st_storage_name,
-                "group": self._group.value,
-                "injectionnominalcapacity": f"{self._injection_nominal_capacity:.6f}",
-                "withdrawalnominalcapacity": f"{self._withdrawal_nominal_capacity:.6f}",
-                "reservoircapacity": f"{self._reservoir_capacity:.6f}",
-                "efficiency": f"{self._efficiency:.6f}",
-                "initiallevel": f"{self._initial_level:.6f}",
-                "initialleveloptim": f"{self._initial_level_optim}".lower(),
-                "enabled": f"{self._enabled}".lower(),
+            f"{self.st_storage_name}": {
+                "name": self.st_storage_name,
+                "group": self.group.value,
+                "injectionnominalcapacity": f"{self.injection_nominal_capacity:.6f}",
+                "withdrawalnominalcapacity": f"{self.withdrawal_nominal_capacity:.6f}",
+                "reservoircapacity": f"{self.reservoir_capacity:.6f}",
+                "efficiency": f"{self.efficiency:.6f}",
+                "initiallevel": f"{self.initial_level:.6f}",
+                "initialleveloptim": f"{self.initial_level_optim}".lower(),
+                "enabled": f"{self.enabled}".lower(),
             }
         }
 
     def yield_st_storage_properties(self) -> STStorageProperties:
-        return STStorageProperties(
-            group=self._group,
-            injection_nominal_capacity=self._injection_nominal_capacity,
-            withdrawal_nominal_capacity=self._withdrawal_nominal_capacity,
-            reservoir_capacity=self._reservoir_capacity,
-            efficiency=self._efficiency,
-            initial_level=self._initial_level,
-            initial_level_optim=self._initial_level_optim,
-            enabled=self._enabled,
-        )
+        excludes = {"st_storage_name", "list_ini_fields"}
+        return STStorageProperties.model_validate(self.model_dump(mode="json", exclude=excludes))
 
 
 class STStorage:

--- a/src/antares/model/st_storage.py
+++ b/src/antares/model/st_storage.py
@@ -42,7 +42,7 @@ class STStorageMatrixName(Enum):
     INFLOWS = "inflows"
 
 
-class NonOptionalSTStorageProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
+class DefaultSTStorageProperties(BaseModel, extra="forbid", populate_by_name=True, alias_generator=to_camel):
     """
     Properties of a short-term storage system read from the configuration files.
 
@@ -61,11 +61,11 @@ class NonOptionalSTStorageProperties(BaseModel, extra="forbid", populate_by_name
 
 
 @all_optional_model
-class STStorageProperties(NonOptionalSTStorageProperties):
+class STStorageProperties(DefaultSTStorageProperties):
     pass
 
 
-class STStoragePropertiesLocal(NonOptionalSTStorageProperties):
+class STStoragePropertiesLocal(DefaultSTStorageProperties):
     st_storage_name: str
 
     @computed_field  # type: ignore[misc]

--- a/src/antares/model/thermal.py
+++ b/src/antares/model/thermal.py
@@ -65,7 +65,7 @@ class ThermalCostGeneration(Enum):
     USE_COST_TIME_SERIES = "useCostTimeseries"
 
 
-class NonOptionalThermalProperties(ClusterProperties):
+class DefaultThermalProperties(ClusterProperties):
     """
     Thermal cluster configuration model.
     This model describes the configuration parameters for a thermal cluster.
@@ -108,11 +108,11 @@ class NonOptionalThermalProperties(ClusterProperties):
 
 
 @all_optional_model
-class ThermalClusterProperties(NonOptionalThermalProperties):
+class ThermalClusterProperties(DefaultThermalProperties):
     pass
 
 
-class ThermalClusterPropertiesLocal(NonOptionalThermalProperties):
+class ThermalClusterPropertiesLocal(DefaultThermalProperties):
     thermal_name: str
 
     @computed_field  # type: ignore[misc]

--- a/src/antares/model/thermal.py
+++ b/src/antares/model/thermal.py
@@ -11,15 +11,14 @@
 # This file is part of the Antares project.
 
 from enum import Enum
-from typing import Optional, Any
+from typing import Optional
 
 import pandas as pd
-from pydantic import BaseModel, computed_field
+from pydantic import computed_field
 
 from antares.model.cluster import ClusterProperties
 from antares.tools.all_optional_meta import all_optional_model
 from antares.tools.contents_tool import transform_name_to_id
-from antares.tools.ini_tool import check_if_none
 
 
 class LawOption(Enum):
@@ -113,139 +112,57 @@ class ThermalClusterProperties(NonOptionalThermalProperties):
     pass
 
 
-class ThermalClusterPropertiesLocal(BaseModel):
-    def __init__(
-        self,
-        thermal_name: str,
-        thermal_cluster_properties: Optional[ThermalClusterProperties] = None,
-        **kwargs: Optional[Any],
-    ):
-        super().__init__(**kwargs)
-        thermal_cluster_properties = thermal_cluster_properties or ThermalClusterProperties()
-        self._thermal_name = thermal_name
-        self._enabled = check_if_none(thermal_cluster_properties.enabled, True)
-        self._unit_count = check_if_none(thermal_cluster_properties.unit_count, 1)
-        self._nominal_capacity = check_if_none(thermal_cluster_properties.nominal_capacity, 0)
-        self._group = (
-            # The value OTHER1 matches AntaresWeb if a cluster is created via API without providing a group
-            thermal_cluster_properties.group or ThermalClusterGroup.OTHER1
-        )
-        self._gen_ts = check_if_none(thermal_cluster_properties.gen_ts, LocalTSGenerationBehavior.USE_GLOBAL)
-        self._min_stable_power = check_if_none(thermal_cluster_properties.min_stable_power, 0)
-        self._min_up_time = check_if_none(thermal_cluster_properties.min_up_time, 1)
-        self._min_down_time = check_if_none(thermal_cluster_properties.min_down_time, 1)
-        self._must_run = check_if_none(thermal_cluster_properties.must_run, False)
-        self._spinning = check_if_none(thermal_cluster_properties.spinning, 0)
-        self._volatility_forced = check_if_none(thermal_cluster_properties.volatility_forced, 0)
-        self._volatility_planned = check_if_none(thermal_cluster_properties.volatility_planned, 0)
-        self._law_forced = check_if_none(thermal_cluster_properties.law_forced, LawOption.UNIFORM)
-        self._law_planned = check_if_none(thermal_cluster_properties.law_planned, LawOption.UNIFORM)
-        self._marginal_cost = check_if_none(thermal_cluster_properties.marginal_cost, 0)
-        self._spread_cost = check_if_none(thermal_cluster_properties.spread_cost, 0)
-        self._fixed_cost = check_if_none(thermal_cluster_properties.fixed_cost, 0)
-        self._startup_cost = check_if_none(thermal_cluster_properties.startup_cost, 0)
-        self._market_bid_cost = check_if_none(thermal_cluster_properties.market_bid_cost, 0)
-        self._co2 = check_if_none(thermal_cluster_properties.co2, 0)
-        self._nh3 = check_if_none(thermal_cluster_properties.nh3, 0)
-        self._so2 = check_if_none(thermal_cluster_properties.so2, 0)
-        self._nox = check_if_none(thermal_cluster_properties.nox, 0)
-        self._pm2_5 = check_if_none(thermal_cluster_properties.pm2_5, 0)
-        self._pm5 = check_if_none(thermal_cluster_properties.pm5, 0)
-        self._pm10 = check_if_none(thermal_cluster_properties.pm10, 0)
-        self._nmvoc = check_if_none(thermal_cluster_properties.nmvoc, 0)
-        self._op1 = check_if_none(thermal_cluster_properties.op1, 0)
-        self._op2 = check_if_none(thermal_cluster_properties.op2, 0)
-        self._op3 = check_if_none(thermal_cluster_properties.op3, 0)
-        self._op4 = check_if_none(thermal_cluster_properties.op4, 0)
-        self._op5 = check_if_none(thermal_cluster_properties.op5, 0)
-        self._cost_generation = check_if_none(
-            thermal_cluster_properties.cost_generation, ThermalCostGeneration.SET_MANUALLY
-        )
-        self._efficiency = check_if_none(thermal_cluster_properties.efficiency, 100)
-        self._variable_o_m_cost = check_if_none(thermal_cluster_properties.variable_o_m_cost, 0)
+class ThermalClusterPropertiesLocal(NonOptionalThermalProperties):
+    thermal_name: str
 
     @computed_field  # type: ignore[misc]
     @property
     def list_ini_fields(self) -> dict[str, dict[str, str]]:
+        # todo: This is horrible. Should be handled via aliases ...
         return {
-            f"{self._thermal_name}": {
-                "group": self._group.value,
-                "name": self._thermal_name,
-                "enabled": f"{self._enabled}",
-                "unitcount": f"{self._unit_count}",
-                "nominalcapacity": f"{self._nominal_capacity:.6f}",
-                "gen-ts": self._gen_ts.value,
-                "min-stable-power": f"{self._min_stable_power:.6f}",
-                "min-up-time": f"{self._min_up_time}",
-                "min-down-time": f"{self._min_down_time}",
-                "must-run": f"{self._must_run}",
-                "spinning": f"{self._spinning:.6f}",
-                "volatility.forced": f"{self._volatility_forced:.6f}",
-                "volatility.planned": f"{self._volatility_planned:.6f}",
-                "law.forced": self._law_forced.value,
-                "law.planned": self._law_planned.value,
-                "marginal-cost": f"{self._marginal_cost:.6f}",
-                "spread-cost": f"{self._spread_cost:.6f}",
-                "fixed-cost": f"{self._fixed_cost:.6f}",
-                "startup-cost": f"{self._startup_cost:.6f}",
-                "market-bid-cost": f"{self._market_bid_cost:.6f}",
-                "co2": f"{self._co2:.6f}",
-                "nh3": f"{self._nh3:.6f}",
-                "so2": f"{self._so2:.6f}",
-                "nox": f"{self._nox:.6f}",
-                "pm2_5": f"{self._pm2_5:.6f}",
-                "pm5": f"{self._pm5:.6f}",
-                "pm10": f"{self._pm10:.6f}",
-                "nmvoc": f"{self._nmvoc:.6f}",
-                "op1": f"{self._op1:.6f}",
-                "op2": f"{self._op2:.6f}",
-                "op3": f"{self._op3:.6f}",
-                "op4": f"{self._op4:.6f}",
-                "op5": f"{self._op5:.6f}",
-                "costgeneration": self._cost_generation.value,
-                "efficiency": f"{self._efficiency:.6f}",
-                "variableomcost": f"{self._variable_o_m_cost:.6f}",
+            f"{self.thermal_name}": {
+                "group": self.group.value,
+                "name": self.thermal_name,
+                "enabled": f"{self.enabled}",
+                "unitcount": f"{self.unit_count}",
+                "nominalcapacity": f"{self.nominal_capacity:.6f}",
+                "gen-ts": self.gen_ts.value,
+                "min-stable-power": f"{self.min_stable_power:.6f}",
+                "min-up-time": f"{self.min_up_time}",
+                "min-down-time": f"{self.min_down_time}",
+                "must-run": f"{self.must_run}",
+                "spinning": f"{self.spinning:.6f}",
+                "volatility.forced": f"{self.volatility_forced:.6f}",
+                "volatility.planned": f"{self.volatility_planned:.6f}",
+                "law.forced": self.law_forced.value,
+                "law.planned": self.law_planned.value,
+                "marginal-cost": f"{self.marginal_cost:.6f}",
+                "spread-cost": f"{self.spread_cost:.6f}",
+                "fixed-cost": f"{self.fixed_cost:.6f}",
+                "startup-cost": f"{self.startup_cost:.6f}",
+                "market-bid-cost": f"{self.market_bid_cost:.6f}",
+                "co2": f"{self.co2:.6f}",
+                "nh3": f"{self.nh3:.6f}",
+                "so2": f"{self.so2:.6f}",
+                "nox": f"{self.nox:.6f}",
+                "pm2_5": f"{self.pm2_5:.6f}",
+                "pm5": f"{self.pm5:.6f}",
+                "pm10": f"{self.pm10:.6f}",
+                "nmvoc": f"{self.nmvoc:.6f}",
+                "op1": f"{self.op1:.6f}",
+                "op2": f"{self.op2:.6f}",
+                "op3": f"{self.op3:.6f}",
+                "op4": f"{self.op4:.6f}",
+                "op5": f"{self.op5:.6f}",
+                "costgeneration": self.cost_generation.value,
+                "efficiency": f"{self.efficiency:.6f}",
+                "variableomcost": f"{self.variable_o_m_cost:.6f}",
             }
         }
 
     def yield_thermal_cluster_properties(self) -> ThermalClusterProperties:
-        return ThermalClusterProperties(
-            group=self._group,
-            enabled=self._enabled,
-            unit_count=self._unit_count,
-            nominal_capacity=self._nominal_capacity,
-            gen_ts=self._gen_ts,
-            min_stable_power=self._min_stable_power,
-            min_up_time=self._min_up_time,
-            min_down_time=self._min_down_time,
-            must_run=self._must_run,
-            spinning=self._spinning,
-            volatility_forced=self._volatility_forced,
-            volatility_planned=self._volatility_planned,
-            law_forced=self._law_forced,
-            law_planned=self._law_planned,
-            marginal_cost=self._marginal_cost,
-            spread_cost=self._spread_cost,
-            fixed_cost=self._fixed_cost,
-            startup_cost=self._startup_cost,
-            market_bid_cost=self._market_bid_cost,
-            co2=self._co2,
-            nh3=self._nh3,
-            so2=self._so2,
-            nox=self._nox,
-            pm2_5=self._pm2_5,
-            pm5=self._pm5,
-            pm10=self._pm10,
-            nmvoc=self._nmvoc,
-            op1=self._op1,
-            op2=self._op2,
-            op3=self._op3,
-            op4=self._op4,
-            op5=self._op5,
-            cost_generation=self._cost_generation,
-            efficiency=self._efficiency,
-            variable_o_m_cost=self._variable_o_m_cost,
-        )
+        excludes = {"thermal_name", "list_ini_fields"}
+        return ThermalClusterProperties.model_validate(self.model_dump(mode="json", exclude=excludes))
 
 
 class ThermalClusterMatrixName(Enum):

--- a/src/antares/model/thermal.py
+++ b/src/antares/model/thermal.py
@@ -118,7 +118,7 @@ class ThermalClusterPropertiesLocal(NonOptionalThermalProperties):
     @computed_field  # type: ignore[misc]
     @property
     def list_ini_fields(self) -> dict[str, dict[str, str]]:
-        # todo: This is horrible. Should be handled via aliases ...
+        # todo: Should be handled via aliases
         return {
             f"{self.thermal_name}": {
                 "group": self.group.value,

--- a/src/antares/model/thermal.py
+++ b/src/antares/model/thermal.py
@@ -118,7 +118,6 @@ class ThermalClusterPropertiesLocal(NonOptionalThermalProperties):
     @computed_field  # type: ignore[misc]
     @property
     def list_ini_fields(self) -> dict[str, dict[str, str]]:
-        # todo: Should be handled via aliases
         return {
             f"{self.thermal_name}": {
                 "group": self.group.value,

--- a/src/antares/model/thermal.py
+++ b/src/antares/model/thermal.py
@@ -17,6 +17,7 @@ import pandas as pd
 from pydantic import BaseModel, computed_field
 
 from antares.model.cluster import ClusterProperties
+from antares.tools.all_optional_meta import all_optional_model
 from antares.tools.contents_tool import transform_name_to_id
 from antares.tools.ini_tool import check_if_none
 
@@ -65,46 +66,51 @@ class ThermalCostGeneration(Enum):
     USE_COST_TIME_SERIES = "useCostTimeseries"
 
 
-class ThermalClusterProperties(ClusterProperties):
+class NonOptionalThermalProperties(ClusterProperties):
     """
     Thermal cluster configuration model.
     This model describes the configuration parameters for a thermal cluster.
     """
 
-    group: Optional[ThermalClusterGroup] = None
-    gen_ts: Optional[LocalTSGenerationBehavior] = None
-    min_stable_power: Optional[float] = None
-    min_up_time: Optional[int] = None
-    min_down_time: Optional[int] = None
-    must_run: Optional[bool] = None
-    spinning: Optional[float] = None
-    volatility_forced: Optional[float] = None
-    volatility_planned: Optional[float] = None
-    law_forced: Optional[LawOption] = None
-    law_planned: Optional[LawOption] = None
-    marginal_cost: Optional[float] = None
-    spread_cost: Optional[float] = None
-    fixed_cost: Optional[float] = None
-    startup_cost: Optional[float] = None
-    market_bid_cost: Optional[float] = None
-    co2: Optional[float] = None
+    group: ThermalClusterGroup = ThermalClusterGroup.OTHER1
+    gen_ts: LocalTSGenerationBehavior = LocalTSGenerationBehavior.USE_GLOBAL
+    min_stable_power: float = 0
+    min_up_time: int = 1
+    min_down_time: int = 1
+    must_run: bool = False
+    spinning: float = 0
+    volatility_forced: float = 0
+    volatility_planned: float = 0
+    law_forced: LawOption = LawOption.UNIFORM
+    law_planned: LawOption = LawOption.UNIFORM
+    marginal_cost: float = 0
+    spread_cost: float = 0
+    fixed_cost: float = 0
+    startup_cost: float = 0
+    market_bid_cost: float = 0
+    co2: float = 0
     # version 860
-    nh3: Optional[float] = None
-    so2: Optional[float] = None
-    nox: Optional[float] = None
-    pm2_5: Optional[float] = None
-    pm5: Optional[float] = None
-    pm10: Optional[float] = None
-    nmvoc: Optional[float] = None
-    op1: Optional[float] = None
-    op2: Optional[float] = None
-    op3: Optional[float] = None
-    op4: Optional[float] = None
-    op5: Optional[float] = None
+    nh3: float = 0
+    so2: float = 0
+    nox: float = 0
+    pm2_5: float = 0
+    pm5: float = 0
+    pm10: float = 0
+    nmvoc: float = 0
+    op1: float = 0
+    op2: float = 0
+    op3: float = 0
+    op4: float = 0
+    op5: float = 0
     # version 870
-    cost_generation: Optional[ThermalCostGeneration] = None
-    efficiency: Optional[float] = None
-    variable_o_m_cost: Optional[float] = None
+    cost_generation: ThermalCostGeneration = ThermalCostGeneration.SET_MANUALLY
+    efficiency: float = 100
+    variable_o_m_cost: float = 0
+
+
+@all_optional_model
+class ThermalClusterProperties(NonOptionalThermalProperties):
+    pass
 
 
 class ThermalClusterPropertiesLocal(BaseModel):

--- a/src/antares/service/local_services/area_local.py
+++ b/src/antares/service/local_services/area_local.py
@@ -170,7 +170,9 @@ class AreaLocalService(BaseAreaService):
         properties: Optional[HydroProperties] = None,
         matrices: Optional[Dict[HydroMatrixName, pd.DataFrame]] = None,
     ) -> Hydro:
-        local_hydro_properties = HydroPropertiesLocal(area_id, properties)
+        properties = properties or HydroProperties()
+        args = {"area_id": area_id, **properties.model_dump(mode="json", exclude_none=True)}
+        local_hydro_properties = HydroPropertiesLocal.model_validate(args)
 
         list_ini = IniFile(self.config.study_path, IniFileTypes.HYDRO_INI)
         list_ini.add_section(local_hydro_properties.hydro_ini_fields)

--- a/src/antares/service/local_services/area_local.py
+++ b/src/antares/service/local_services/area_local.py
@@ -109,7 +109,9 @@ class AreaLocalService(BaseAreaService):
         properties: Optional[RenewableClusterProperties] = None,
         series: Optional[pd.DataFrame] = None,
     ) -> RenewableCluster:
-        local_properties = RenewableClusterPropertiesLocal(renewable_name, properties)
+        properties = properties or RenewableClusterProperties()
+        args = {"renewable_name": renewable_name, **properties.model_dump(mode="json", exclude_none=True)}
+        local_properties = RenewableClusterPropertiesLocal.model_validate(args)
 
         list_ini = IniFile(self.config.study_path, IniFileTypes.RENEWABLES_LIST_INI, area_name=area_id)
         list_ini.add_section(local_properties.ini_fields)

--- a/src/antares/service/local_services/area_local.py
+++ b/src/antares/service/local_services/area_local.py
@@ -77,7 +77,9 @@ class AreaLocalService(BaseAreaService):
         thermal_name: str,
         properties: Optional[ThermalClusterProperties] = None,
     ) -> ThermalCluster:
-        local_thermal_properties = ThermalClusterPropertiesLocal(thermal_name, properties)
+        properties = properties or ThermalClusterProperties()
+        args = {"thermal_name": thermal_name, **properties.model_dump(mode="json", exclude_none=True)}
+        local_thermal_properties = ThermalClusterPropertiesLocal.model_validate(args)
 
         list_ini = IniFile(self.config.study_path, IniFileTypes.THERMAL_LIST_INI, area_name=area_id)
         list_ini.add_section(local_thermal_properties.list_ini_fields)

--- a/src/antares/service/local_services/area_local.py
+++ b/src/antares/service/local_services/area_local.py
@@ -245,9 +245,7 @@ class AreaLocalService(BaseAreaService):
             adequacy_patch_ini.write_ini_file()
 
             optimization_ini = ConfigParser()
-            args = {"nodal_optimization": local_properties.nodal_optimization}
-            args.update({"filtering": local_properties.filtering})
-            optimization_ini.read_dict(args)
+            optimization_ini.read_dict(local_properties.yield_local_dict())
 
             with open(new_area_directory / "optimization.ini", "w") as optimization_ini_file:
                 optimization_ini.write(optimization_ini_file)

--- a/src/antares/service/local_services/area_local.py
+++ b/src/antares/service/local_services/area_local.py
@@ -129,7 +129,9 @@ class AreaLocalService(BaseAreaService):
     def create_st_storage(
         self, area_id: str, st_storage_name: str, properties: Optional[STStorageProperties] = None
     ) -> STStorage:
-        local_st_storage_properties = STStoragePropertiesLocal(st_storage_name, properties)
+        properties = properties or STStorageProperties()
+        args = {"st_storage_name": st_storage_name, **properties.model_dump(mode="json", exclude_none=True)}
+        local_st_storage_properties = STStoragePropertiesLocal.model_validate(args)
 
         list_ini = IniFile(self.config.study_path, IniFileTypes.ST_STORAGE_LIST_INI, area_name=area_id)
         list_ini.add_section(local_st_storage_properties.list_ini_fields)

--- a/src/antares/service/local_services/link_local.py
+++ b/src/antares/service/local_services/link_local.py
@@ -65,8 +65,12 @@ class LinkLocalService(BaseLinkService):
         link_dir = self.config.study_path / "input/links" / area_from.name
         os.makedirs(link_dir, exist_ok=True)
 
-        local_properties = LinkPropertiesLocal(properties) if properties else LinkPropertiesLocal()
-        local_ui = LinkUiLocal(ui) if ui else LinkUiLocal()
+        local_properties = (
+            LinkPropertiesLocal.model_validate(properties.model_dump(mode="json", exclude_none=True))
+            if properties
+            else LinkPropertiesLocal()
+        )
+        local_ui = LinkUiLocal.model_validate(ui.model_dump(mode="json", exclude_none=True)) if ui else LinkUiLocal()
 
         properties_ini_file = link_dir / "properties.ini"
         properties_ini = configparser.ConfigParser()

--- a/src/antares/tools/all_optional_meta.py
+++ b/src/antares/tools/all_optional_meta.py
@@ -1,0 +1,25 @@
+import copy
+import typing as t
+from pydantic import BaseModel, create_model
+
+ModelClass = t.TypeVar("ModelClass", bound=BaseModel)
+
+
+def all_optional_model(model: t.Type[ModelClass]) -> t.Type[ModelClass]:
+    """
+    This decorator can be used to make all fields of a pydantic model optionals.
+
+    Args:
+        model: The pydantic model to modify.
+
+    Returns:
+        The modified model.
+    """
+    kwargs = {}
+    for field_name, field_info in model.model_fields.items():
+        new = copy.deepcopy(field_info)
+        new.default = None
+        new.annotation = t.Optional[field_info.annotation]  # type: ignore
+        kwargs[field_name] = (new.annotation, new)
+
+    return create_model(f"Partial{model.__name__}", __base__=model, __module__=model.__module__, **kwargs)  # type: ignore

--- a/src/antares/tools/all_optional_meta.py
+++ b/src/antares/tools/all_optional_meta.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
 import copy
 import typing as t
 from pydantic import BaseModel, create_model

--- a/src/antares/tools/ini_tool.py
+++ b/src/antares/tools/ini_tool.py
@@ -149,7 +149,3 @@ class IniFile:
         for section in ini_to_sort.sections():
             sorted_ini[section] = {key: value for (key, value) in sorted(list(ini_to_sort[section].items()))}
         return sorted_ini
-
-
-def check_if_none(value_to_check: Any, default_value: Any) -> Any:
-    return value_to_check if value_to_check is not None else default_value

--- a/tests/antares/services/local_services/test_area.py
+++ b/tests/antares/services/local_services/test_area.py
@@ -331,12 +331,11 @@ ts-interpretation = power-generation
 
     def test_renewable_cluster_and_ini_have_custom_properties(self, local_study_w_thermal, actual_renewable_list_ini):
         # Given
-        custom_properties = RenewableClusterPropertiesLocal(
-            "renewable cluster",
-            RenewableClusterProperties(
-                group=RenewableClusterGroup.WIND_OFF_SHORE, ts_interpretation=TimeSeriesInterpretation.PRODUCTION_FACTOR
-            ),
+        props = RenewableClusterProperties(
+            group=RenewableClusterGroup.WIND_OFF_SHORE, ts_interpretation=TimeSeriesInterpretation.PRODUCTION_FACTOR
         )
+        args = {"renewable_name": "renewable cluster", **props.model_dump(mode="json", exclude_none=True)}
+        custom_properties = RenewableClusterPropertiesLocal.model_validate(args)
         expected_renewables_list_ini_content = """[renewable cluster]
 name = renewable cluster
 group = Wind Offshore

--- a/tests/antares/services/local_services/test_area.py
+++ b/tests/antares/services/local_services/test_area.py
@@ -421,10 +421,9 @@ enabled = true
 
     def test_st_storage_and_ini_have_custom_properties(self, local_study_with_st_storage, actual_st_storage_list_ini):
         # Given
-        custom_properties = STStoragePropertiesLocal(
-            "short term storage",
-            STStorageProperties(group=STStorageGroup.BATTERY, reservoir_capacity=12.345),
-        )
+        props = STStorageProperties(group=STStorageGroup.BATTERY, reservoir_capacity=12.345)
+        args = {"st_storage_name": "short term storage", **props.model_dump(mode="json", exclude_none=True)}
+        custom_properties = STStoragePropertiesLocal.model_validate(args)
         expected_st_storage_list_ini_content = """[short term storage]
 name = short term storage
 group = Battery

--- a/tests/antares/services/local_services/test_area.py
+++ b/tests/antares/services/local_services/test_area.py
@@ -225,14 +225,11 @@ variableomcost = 5.000000
     ):
         # Given
         local_study_w_thermal.get_areas()["fr"].create_thermal_cluster("test thermal cluster two")
-        expected_list_ini_dict = ThermalClusterPropertiesLocal(
-            thermal_name="test thermal cluster", thermal_cluster_properties=default_thermal_cluster_properties
-        ).list_ini_fields
-        expected_list_ini_dict.update(
-            ThermalClusterPropertiesLocal(
-                thermal_name="test thermal cluster two", thermal_cluster_properties=default_thermal_cluster_properties
-            ).list_ini_fields
-        )
+        args = default_thermal_cluster_properties.model_dump(mode="json", exclude_none=True)
+        args["thermal_name"] = "test thermal cluster"
+        expected_list_ini_dict = ThermalClusterPropertiesLocal.model_validate(args).list_ini_fields
+        args["thermal_name"] = "test thermal cluster two"
+        expected_list_ini_dict.update(ThermalClusterPropertiesLocal.model_validate(args).list_ini_fields)
 
         expected_list_ini = ConfigParser()
         expected_list_ini.read_dict(expected_list_ini_dict)
@@ -251,20 +248,13 @@ variableomcost = 5.000000
         first_cluster_alphabetically = "a is before b and t"
         second_cluster_alphabetically = "b is after a"
 
-        expected_list_ini_dict = ThermalClusterPropertiesLocal(
-            thermal_name=first_cluster_alphabetically, thermal_cluster_properties=default_thermal_cluster_properties
-        ).list_ini_fields
-        expected_list_ini_dict.update(
-            ThermalClusterPropertiesLocal(
-                thermal_name=second_cluster_alphabetically,
-                thermal_cluster_properties=default_thermal_cluster_properties,
-            ).list_ini_fields
-        )
-        expected_list_ini_dict.update(
-            ThermalClusterPropertiesLocal(
-                thermal_name="test thermal cluster", thermal_cluster_properties=default_thermal_cluster_properties
-            ).list_ini_fields
-        )
+        args = default_thermal_cluster_properties.model_dump(mode="json", exclude_none=True)
+        args["thermal_name"] = first_cluster_alphabetically
+        expected_list_ini_dict = ThermalClusterPropertiesLocal.model_validate(args).list_ini_fields
+        args["thermal_name"] = second_cluster_alphabetically
+        expected_list_ini_dict.update(ThermalClusterPropertiesLocal.model_validate(args).list_ini_fields)
+        args["thermal_name"] = "test thermal cluster"
+        expected_list_ini_dict.update(ThermalClusterPropertiesLocal.model_validate(args).list_ini_fields)
         expected_list_ini = ConfigParser()
         expected_list_ini.read_dict(expected_list_ini_dict)
 

--- a/tests/antares/services/local_services/test_study.py
+++ b/tests/antares/services/local_services/test_study.py
@@ -541,7 +541,7 @@ layers = 0
 
         # When
         actual_area_properties = local_study_w_areas.get_areas()["fr"].properties
-        actual_properties = AreaPropertiesLocal(actual_area_properties).model_dump(exclude_none=True)
+        actual_properties = AreaPropertiesLocal.model_validate(actual_area_properties).model_dump(exclude_none=True)
 
         assert expected_default_properties == actual_properties
 
@@ -572,7 +572,9 @@ layers = 0
 
         # When
         created_area = local_study.create_area(area_name=area_to_create, properties=area_properties)
-        actual_properties = AreaPropertiesLocal(created_area.properties).model_dump(exclude_none=True)
+        actual_properties = AreaPropertiesLocal.model_validate(
+            created_area.properties.model_dump(mode="json")
+        ).model_dump(exclude_none=True)
 
         assert expected_properties == actual_properties
 
@@ -767,7 +769,7 @@ filter-year-by-year = hourly, daily, weekly, monthly, annual
 """
         expected_ini = ConfigParser()
         expected_ini.read_string(expected_ini_content)
-        default_properties = LinkPropertiesLocal(LinkProperties()).yield_link_properties()
+        default_properties = LinkPropertiesLocal().yield_link_properties()
 
         # When
         area_from, area_to = link_to_create.split("_")
@@ -834,7 +836,12 @@ filter-year-by-year = daily, weekly
 
         # Then
         assert actual_ini_content == expected_ini_content
-        assert link_created.properties == LinkPropertiesLocal(link_properties).yield_link_properties()
+        assert (
+            link_created.properties
+            == LinkPropertiesLocal.model_validate(
+                link_properties.model_dump(mode="json", exclude_none=True)
+            ).yield_link_properties()
+        )
         assert expected_ini == actual_ini
 
     def test_multiple_links_created_from_same_area(self, tmp_path, local_study_w_areas):
@@ -1068,5 +1075,13 @@ filter-year-by-year = hourly, daily, weekly, monthly, annual
         assert isinstance(local_study_w_areas.get_links()[link_to_create].ui, LinkUi)
         assert actual_ini == expected_ini
         assert actual_ini_string == expected_ini_string
-        assert actual_properties == LinkPropertiesLocal(expected_properties).yield_link_properties()
-        assert actual_ui == LinkUiLocal(expected_ui).yield_link_ui()
+        assert (
+            actual_properties
+            == LinkPropertiesLocal.model_validate(
+                expected_properties.model_dump(mode="json", exclude_none=True)
+            ).yield_link_properties()
+        )
+        assert (
+            actual_ui
+            == LinkUiLocal.model_validate(expected_ui.model_dump(mode="json", exclude_none=True)).yield_link_ui()
+        )

--- a/tests/antares/services/local_services/test_study.py
+++ b/tests/antares/services/local_services/test_study.py
@@ -387,7 +387,7 @@ filter-year-by-year = hourly, daily, weekly, monthly, annual
             actual_optimization_ini_content = file.read()
 
         # Then
-        assert actual_optimization_ini == expected_optimization_ini
+        # assert actual_optimization_ini == expected_optimization_ini
         assert actual_optimization_ini_content == expected_optimization_ini_content
 
     def test_custom_area_optimization_ini_content(self, tmp_path, local_study):
@@ -524,7 +524,7 @@ layers = 0
     def test_areas_have_default_properties(self, tmp_path, local_study_w_areas):
         # Given
         expected_default_properties = {
-            "nodal_optimization": {
+            "nodal optimization": {
                 "non-dispatchable-power": "true",
                 "dispatchable-hydro-power": "true",
                 "other-dispatchable-power": "true",
@@ -541,7 +541,9 @@ layers = 0
 
         # When
         actual_area_properties = local_study_w_areas.get_areas()["fr"].properties
-        actual_properties = AreaPropertiesLocal.model_validate(actual_area_properties).model_dump(exclude_none=True)
+        actual_properties = AreaPropertiesLocal.model_validate(
+            actual_area_properties.model_dump(mode="json", exclude_none=True)
+        ).yield_local_dict()
 
         assert expected_default_properties == actual_properties
 
@@ -555,7 +557,7 @@ layers = 0
             filter_by_year={FilterOption.ANNUAL, FilterOption.ANNUAL, FilterOption.HOURLY, FilterOption.WEEKLY},
         )
         expected_properties = {
-            "nodal_optimization": {
+            "nodal optimization": {
                 "non-dispatchable-power": "true",
                 "dispatchable-hydro-power": "false",
                 "other-dispatchable-power": "true",
@@ -574,7 +576,7 @@ layers = 0
         created_area = local_study.create_area(area_name=area_to_create, properties=area_properties)
         actual_properties = AreaPropertiesLocal.model_validate(
             created_area.properties.model_dump(mode="json")
-        ).model_dump(exclude_none=True)
+        ).yield_local_dict()
 
         assert expected_properties == actual_properties
 

--- a/tests/antares/services/local_services/test_study.py
+++ b/tests/antares/services/local_services/test_study.py
@@ -387,7 +387,7 @@ filter-year-by-year = hourly, daily, weekly, monthly, annual
             actual_optimization_ini_content = file.read()
 
         # Then
-        # assert actual_optimization_ini == expected_optimization_ini
+        assert actual_optimization_ini == expected_optimization_ini
         assert actual_optimization_ini_content == expected_optimization_ini_content
 
     def test_custom_area_optimization_ini_content(self, tmp_path, local_study):
@@ -541,9 +541,8 @@ layers = 0
 
         # When
         actual_area_properties = local_study_w_areas.get_areas()["fr"].properties
-        actual_properties = AreaPropertiesLocal.model_validate(
-            actual_area_properties.model_dump(mode="json", exclude_none=True)
-        ).yield_local_dict()
+        created_properties = actual_area_properties.model_dump(mode="json", exclude_none=True)
+        actual_properties = AreaPropertiesLocal.model_validate(created_properties).yield_local_dict()
 
         assert expected_default_properties == actual_properties
 
@@ -574,10 +573,8 @@ layers = 0
 
         # When
         created_area = local_study.create_area(area_name=area_to_create, properties=area_properties)
-        actual_properties = AreaPropertiesLocal.model_validate(
-            created_area.properties.model_dump(mode="json")
-        ).yield_local_dict()
-
+        created_properties = created_area.properties.model_dump(mode="json", exclude_none=True)
+        actual_properties = AreaPropertiesLocal.model_validate(created_properties).yield_local_dict()
         assert expected_properties == actual_properties
 
     def test_areas_ini_has_correct_sections(self, actual_thermal_areas_ini):
@@ -838,12 +835,8 @@ filter-year-by-year = daily, weekly
 
         # Then
         assert actual_ini_content == expected_ini_content
-        assert (
-            link_created.properties
-            == LinkPropertiesLocal.model_validate(
-                link_properties.model_dump(mode="json", exclude_none=True)
-            ).yield_link_properties()
-        )
+        created_properties = link_properties.model_dump(mode="json", exclude_none=True)
+        assert link_created.properties == LinkPropertiesLocal.model_validate(created_properties).yield_link_properties()
         assert expected_ini == actual_ini
 
     def test_multiple_links_created_from_same_area(self, tmp_path, local_study_w_areas):
@@ -1077,13 +1070,7 @@ filter-year-by-year = hourly, daily, weekly, monthly, annual
         assert isinstance(local_study_w_areas.get_links()[link_to_create].ui, LinkUi)
         assert actual_ini == expected_ini
         assert actual_ini_string == expected_ini_string
-        assert (
-            actual_properties
-            == LinkPropertiesLocal.model_validate(
-                expected_properties.model_dump(mode="json", exclude_none=True)
-            ).yield_link_properties()
-        )
-        assert (
-            actual_ui
-            == LinkUiLocal.model_validate(expected_ui.model_dump(mode="json", exclude_none=True)).yield_link_ui()
-        )
+        created_properties = expected_properties.model_dump(mode="json", exclude_none=True)
+        assert actual_properties == LinkPropertiesLocal.model_validate(created_properties).yield_link_properties()
+        created_ui = expected_ui.model_dump(mode="json", exclude_none=True)
+        assert actual_ui == LinkUiLocal.model_validate(created_ui).yield_link_ui()


### PR DESCRIPTION
Thanks to a home-made `all_optional_model` decorator (copy of the one I've created inside Antares Web) we're able to create a class that have all default values, example:
```python
class NonOptionalSTStorageProperties(BaseModel):
    withdrawal_nominal_capacity: float = 0
    efficiency: float = 1
    initial_level: float = 0.5
    enabled: bool = True
```

and another class 

```python
@all_optional_model
class STStorageProperties(NonOptionalSTStorageProperties):
    pass
```

Thanks to this we avoid this horrible code: 

```python
self._withdrawal_nominal_capacity = check_if_none(st_storage_properties.withdrawal_nominal_capacity, 0)
self._efficiency = check_if_none(st_storage_properties.efficiency, 1)
self._initial_level = check_if_none(st_storage_properties.initial_level, 0.5)
self._enabled = check_if_none(st_storage_properties.enabled, True)
```

and this code (not better):

```python
return STStorageProperties(
    group=self._group,
    injection_nominal_capacity=self._injection_nominal_capacity,
    withdrawal_nominal_capacity=self._withdrawal_nominal_capacity,
    reservoir_capacity=self._reservoir_capacity,
    efficiency=self._efficiency,
    initial_level=self._initial_level,
    initial_level_optim=self._initial_level_optim,
    enabled=self._enabled,
)
```


**IMO it's a better way to do things but we can discuss that**