### PR TITLE
ci(lint): forbid wrong typing inside the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Performs Ubuntu tests
         if: matrix.os != 'windows-latest'
         run: |
-          tox -e lint-github
+          tox -e lint-ci
           tox -p
 
       - name: Performs Windows tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
 
       - name: Performs Ubuntu tests
         if: matrix.os != 'windows-latest'
-        run: tox -p
+        run: |
+          tox -e lint-github
+          tox -p
 
       - name: Performs Windows tests
         if: matrix.os == 'windows-latest'

--- a/src/antares/service/api_services/renewable_api.py
+++ b/src/antares/service/api_services/renewable_api.py
@@ -53,14 +53,7 @@ class RenewableApiService(BaseRenewableService):
 
     def get_renewable_matrix(self, cluster_id: str, area_id: str) -> pd.DataFrame:
         try:
-            path = (
-                PurePosixPath("input")
-                / "renewables"
-                / "series"
-                / f"{area_id}"
-                / f"{cluster_id}"
-                / "series"
-            )
+            path = PurePosixPath("input") / "renewables" / "series" / f"{area_id}" / f"{cluster_id}" / "series"
             return get_matrix(f"{self._base_url}/studies/{self.study_id}/raw?path={path}", self._wrapper)
         except APIError as e:
             raise RenewableMatrixDownloadError(area_id, cluster_id, e.message) from e

--- a/src/antares/service/base_services.py
+++ b/src/antares/service/base_services.py
@@ -521,9 +521,7 @@ class BaseRenewableService(ABC):
         pass
 
     @abstractmethod
-    def get_renewable_matrix(
-        self, cluster_id: str, area_id: str
-    ) -> pd.DataFrame:
+    def get_renewable_matrix(self, cluster_id: str, area_id: str) -> pd.DataFrame:
         """
         Args:
             cluster_id: renewable cluster id to retrieve matrix

--- a/src/antares/service/local_services/area_local.py
+++ b/src/antares/service/local_services/area_local.py
@@ -320,7 +320,7 @@ class AreaLocalService(BaseAreaService):
         return read_timeseries(TimeSeriesFileType.LOAD, self.config.study_path, area_id=area.id)
 
     def get_solar_matrix(self, area: Area) -> pd.DataFrame:
-       return read_timeseries(TimeSeriesFileType.SOLAR, self.config.study_path, area_id=area.id)
+        return read_timeseries(TimeSeriesFileType.SOLAR, self.config.study_path, area_id=area.id)
 
     def get_wind_matrix(self, area: Area) -> pd.DataFrame:
         return read_timeseries(TimeSeriesFileType.WIND, self.config.study_path, area_id=area.id)
@@ -330,7 +330,7 @@ class AreaLocalService(BaseAreaService):
 
     def get_misc_gen_matrix(self, area: Area) -> pd.DataFrame:
         return read_timeseries(TimeSeriesFileType.MISC_GEN, self.config.study_path, area_id=area.id)
-    
+
     def read_areas(self) -> List[Area]:
         local_path = self.config.local_path
         areas_path = local_path / self.study_name / "input" / "areas"

--- a/src/antares/service/local_services/renewable_local.py
+++ b/src/antares/service/local_services/renewable_local.py
@@ -33,15 +33,11 @@ class RenewableLocalService(BaseRenewableService):
         self, renewable_cluster: RenewableCluster, properties: RenewableClusterProperties
     ) -> RenewableClusterProperties:
         raise NotImplementedError
-    
 
-    def get_renewable_matrix(
-        self,
-        cluster_id: str,
-        area_id: str
-    ) -> pd.DataFrame:
-        return read_timeseries(TimeSeriesFileType.RENEWABLE_DATA_SERIES, self.config.study_path, area_id=area_id, cluster_id=cluster_id)
-
+    def get_renewable_matrix(self, cluster_id: str, area_id: str) -> pd.DataFrame:
+        return read_timeseries(
+            TimeSeriesFileType.RENEWABLE_DATA_SERIES, self.config.study_path, area_id=area_id, cluster_id=cluster_id
+        )
 
     def read_renewables(self, area_id: str) -> List[RenewableCluster]:
         renewable_dict = IniFile(self.config.study_path, IniFileTypes.RENEWABLES_LIST_INI, area_name=area_id).ini_dict
@@ -56,6 +52,12 @@ class RenewableLocalService(BaseRenewableService):
                     nominal_capacity=renewable_dict[renewable_cluster]["nominalcapacity"],
                     ts_interpretation=renewable_dict[renewable_cluster]["ts-interpretation"],
                 )
-                renewables_clusters.append(RenewableCluster(renewable_service=self, area_id=area_id, name=renewable_dict[renewable_cluster]["name"], properties=renewable_properties.yield_renewable_cluster_properties()))
+                renewables_clusters.append(
+                    RenewableCluster(
+                        renewable_service=self,
+                        area_id=area_id,
+                        name=renewable_dict[renewable_cluster]["name"],
+                        properties=renewable_properties.yield_renewable_cluster_properties(),
+                    )
+                )
         return renewables_clusters
-    

--- a/src/antares/tools/matrix_tool.py
+++ b/src/antares/tools/matrix_tool.py
@@ -42,7 +42,13 @@ def df_read(path: Path) -> pd.DataFrame:
     return pd.read_csv(path, sep="\t", header=None)
 
 
-def read_timeseries(ts_file_type: TimeSeriesFileType, study_path: Path, area_id: Optional[str] = None, constraint_id: Optional[str] = None, cluster_id: Optional[str] = None,) -> pd.DataFrame:
+def read_timeseries(
+    ts_file_type: TimeSeriesFileType,
+    study_path: Path,
+    area_id: Optional[str] = None,
+    constraint_id: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+) -> pd.DataFrame:
     file_path = study_path / (
         ts_file_type.value
         if not (area_id or constraint_id or cluster_id)

--- a/tests/antares/services/local_services/test_area.py
+++ b/tests/antares/services/local_services/test_area.py
@@ -1122,12 +1122,12 @@ def _write_file(_file_path, _time_series) -> None:
     _file_path.parent.mkdir(parents=True, exist_ok=True)
     _time_series.to_csv(_file_path, sep="\t", header=False, index=False, encoding="utf-8")
 
+
 class TestReadLoad:
     def test_read_load_local(self, local_study_w_areas):
         study_path = local_study_w_areas.service.config.study_path
         local_study_object = read_study_local(study_path)
         areas = local_study_object.read_areas()
-
 
         for area in areas:
             expected_time_serie = pd.DataFrame(
@@ -1158,15 +1158,14 @@ class TestReadRenewable:
         local_study_object = read_study_local(study_path)
         areas = local_study_object.read_areas()
 
-
-
         for area in areas:
             expected_time_serie = pd.DataFrame(
-                    [
-                        [-9999999980506447872, 0, 9999999980506447872],
-                        [0, area.id, 0],
-                    ]
-                , dtype="object")
+                [
+                    [-9999999980506447872, 0, 9999999980506447872],
+                    [0, area.id, 0],
+                ],
+                dtype="object",
+            )
             renewable_list = area.read_renewables(area.id)
 
             if renewable_list:
@@ -1183,9 +1182,9 @@ class TestReadRenewable:
                 assert renewable.properties.group.value == "Other RES 1"
 
                 # Create folder and file for timeserie.
-                cluster_path = study_path / "input" / "renewables" / "series"/ Path(area.id) /  Path(renewable.id)
+                cluster_path = study_path / "input" / "renewables" / "series" / Path(area.id) / Path(renewable.id)
                 os.makedirs(cluster_path, exist_ok=True)
-                series_path = cluster_path / 'series.txt'
+                series_path = cluster_path / "series.txt"
                 _write_file(series_path, expected_time_serie)
 
                 # Check matrix
@@ -1199,14 +1198,14 @@ class TestReadSolar:
         local_study_object = read_study_local(study_path)
         areas = local_study_object.read_areas()
 
-
         for area in areas:
             expected_time_serie = pd.DataFrame(
-                    [
-                        [-9999999980506447872, 0, 9999999980506447872],
-                        [0, area.id, 0],
-                    ]
-                , dtype="object")
+                [
+                    [-9999999980506447872, 0, 9999999980506447872],
+                    [0, area.id, 0],
+                ],
+                dtype="object",
+            )
 
             file_path = study_path / "input" / "solar" / "series" / f"solar_{area.id}.txt"
             _write_file(file_path, expected_time_serie)
@@ -1220,6 +1219,7 @@ class TestReadSolar:
             _write_file(file_path, expected_time_serie)
             matrix = area.get_solar_matrix()
             pd.testing.assert_frame_equal(matrix, expected_time_serie)
+
 
 class TestReadReserves:
     def test_read_reserve_local(self, local_study_w_areas):
@@ -1227,16 +1227,16 @@ class TestReadReserves:
         local_study_object = read_study_local(study_path)
         areas = local_study_object.read_areas()
 
-
         for area in areas:
             expected_time_serie = pd.DataFrame(
-                    [
-                        [-9999999980506447872, 0, 9999999980506447872],
-                        [0, area.id, 0],
-                    ]
-                , dtype="object")
+                [
+                    [-9999999980506447872, 0, 9999999980506447872],
+                    [0, area.id, 0],
+                ],
+                dtype="object",
+            )
 
-            file_path = study_path / "input" / "reserves" /  f"{area.id}.txt"
+            file_path = study_path / "input" / "reserves" / f"{area.id}.txt"
             _write_file(file_path, expected_time_serie)
 
             matrix = area.get_reserves_matrix()
@@ -1244,10 +1244,11 @@ class TestReadReserves:
 
         expected_time_serie = pd.DataFrame([])
         for area in areas:
-            file_path = study_path / "input" / "reserves" /  f"{area.id}.txt"
+            file_path = study_path / "input" / "reserves" / f"{area.id}.txt"
             _write_file(file_path, expected_time_serie)
             matrix = area.get_reserves_matrix()
             pd.testing.assert_frame_equal(matrix, expected_time_serie)
+
 
 class TestReadWind:
     def test_read_wind_local(self, local_study_w_areas):
@@ -1255,15 +1256,15 @@ class TestReadWind:
         local_study_object = read_study_local(study_path)
         areas = local_study_object.read_areas()
 
-
         for area in areas:
             expected_time_serie = pd.DataFrame(
-                    [
-                        [-9999999980506447872, 0, 9999999980506447872],
-                        [0, area.id, 0],
-                    ]
-                , dtype="object")
-            
+                [
+                    [-9999999980506447872, 0, 9999999980506447872],
+                    [0, area.id, 0],
+                ],
+                dtype="object",
+            )
+
             file_path = study_path / "input" / "wind" / "series" / f"wind_{area.id}.txt"
             _write_file(file_path, expected_time_serie)
 
@@ -1277,21 +1278,22 @@ class TestReadWind:
             matrix = area.get_wind_matrix()
             pd.testing.assert_frame_equal(matrix, expected_time_serie)
 
+
 class TestReadmisc_gen:
     def test_read_misc_gen_local(self, local_study_w_areas):
         study_path = local_study_w_areas.service.config.study_path
         local_study_object = read_study_local(study_path)
         areas = local_study_object.read_areas()
 
-
         for area in areas:
             expected_time_serie = pd.DataFrame(
-                    [
-                        [-9999999980506447872, 0, 9999999980506447872],
-                        [0, area.id, 0],
-                    ]
-                , dtype="object")
-            
+                [
+                    [-9999999980506447872, 0, 9999999980506447872],
+                    [0, area.id, 0],
+                ],
+                dtype="object",
+            )
+
             file_path = study_path / "input" / "misc-gen" / f"miscgen-{area.id}.txt"
             _write_file(file_path, expected_time_serie)
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
     ruff format src/ tests/ {posargs}
     mypy {posargs}
 
-[testenv:lint-github]
+[testenv:lint-ci]
 description = Linting and formatting with ruff, typing with mypy
 skip_install = True
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 env_list =
     py3.{9,10,12}-test
-    lint
 
 [testenv]
 deps =
@@ -27,3 +26,10 @@ commands =
     ruff format src/ tests/ {posargs}
     mypy {posargs}
 
+[testenv:lint-github]
+description = Linting and formatting with ruff, typing with mypy
+skip_install = True
+commands =
+    ruff check src/ tests/ {posargs}
+    ruff format --check src/ tests/ {posargs}
+    mypy {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ commands =
 description = Linting and formatting with ruff, typing with mypy
 skip_install = True
 commands =
+    python scripts/license_checker_and_adder.py --path=src --action=check-strict
+    python scripts/license_checker_and_adder.py --path=tests --action=check-strict
     ruff check src/ tests/ {posargs}
     ruff format --check src/ tests/ {posargs}
     mypy {posargs}


### PR DESCRIPTION
Current tox.ini and ci.yml doesn't actually fail if files are incorrectly written (it tries to fix with `ruff check --fix`) or formatted according to the rules in ruff.toml, this corrects that.