### PR TITLE
fix(local): get thermal matrix checked the wrong path

### DIFF
--- a/src/antares/craft/service/local_services/thermal_local.py
+++ b/src/antares/craft/service/local_services/thermal_local.py
@@ -54,7 +54,7 @@ class ThermalLocalService(BaseThermalService):
             time_serie_type,
             self.config.study_path,
             area_id=thermal_cluster.area_id,
-            cluster_id=thermal_cluster.properties.group.value,
+            cluster_id=thermal_cluster.name,
         )
 
     def read_thermal_clusters(self, area_id: str) -> List[ThermalCluster]:

--- a/src/antares/craft/service/local_services/thermal_local.py
+++ b/src/antares/craft/service/local_services/thermal_local.py
@@ -54,7 +54,7 @@ class ThermalLocalService(BaseThermalService):
             time_serie_type,
             self.config.study_path,
             area_id=thermal_cluster.area_id,
-            cluster_id=thermal_cluster.name,
+            cluster_id=thermal_cluster.id,
         )
 
     def read_thermal_clusters(self, area_id: str) -> List[ThermalCluster]:

--- a/tests/antares/services/local_services/test_area.py
+++ b/tests/antares/services/local_services/test_area.py
@@ -927,7 +927,7 @@ class TestReadThermal:
                 assert thermal.properties.cost_generation.value == "SetManually"
 
                 # Create folder and file for timeserie.
-                cluster_path = study_path / "input" / "thermal" / "series" / Path(area.id) / Path(thermal.name)
+                cluster_path = study_path / "input" / "thermal" / "series" / Path(area.id) / Path(thermal.id)
                 series_path = cluster_path / "series.txt"
                 os.makedirs(cluster_path, exist_ok=True)
                 _write_file(series_path, expected_time_serie)
@@ -938,7 +938,7 @@ class TestReadThermal:
                 fuelCost_path = cluster_path / "fuelCost.txt"
                 _write_file(fuelCost_path, expected_time_serie)
 
-                cluster_path = study_path / "input" / "thermal" / "prepro" / Path(area.id) / Path(thermal.name)
+                cluster_path = study_path / "input" / "thermal" / "prepro" / Path(area.id) / Path(thermal.id)
                 os.makedirs(cluster_path, exist_ok=True)
                 series_path_1 = cluster_path / "data.txt"
                 series_path_2 = cluster_path / "modulation.txt"

--- a/tests/antares/services/local_services/test_area.py
+++ b/tests/antares/services/local_services/test_area.py
@@ -927,9 +927,7 @@ class TestReadThermal:
                 assert thermal.properties.cost_generation.value == "SetManually"
 
                 # Create folder and file for timeserie.
-                cluster_path = (
-                    study_path / "input" / "thermal" / "series" / Path(area.id) / Path(thermal.name)
-                )
+                cluster_path = study_path / "input" / "thermal" / "series" / Path(area.id) / Path(thermal.name)
                 series_path = cluster_path / "series.txt"
                 os.makedirs(cluster_path, exist_ok=True)
                 _write_file(series_path, expected_time_serie)
@@ -940,9 +938,7 @@ class TestReadThermal:
                 fuelCost_path = cluster_path / "fuelCost.txt"
                 _write_file(fuelCost_path, expected_time_serie)
 
-                cluster_path = (
-                    study_path / "input" / "thermal" / "prepro" / Path(area.id) / Path(thermal.name)
-                )
+                cluster_path = study_path / "input" / "thermal" / "prepro" / Path(area.id) / Path(thermal.name)
                 os.makedirs(cluster_path, exist_ok=True)
                 series_path_1 = cluster_path / "data.txt"
                 series_path_2 = cluster_path / "modulation.txt"

--- a/tests/antares/services/local_services/test_area.py
+++ b/tests/antares/services/local_services/test_area.py
@@ -928,7 +928,7 @@ class TestReadThermal:
 
                 # Create folder and file for timeserie.
                 cluster_path = (
-                    study_path / "input" / "thermal" / "series" / Path(area.id) / Path(thermal.properties.group.value)
+                    study_path / "input" / "thermal" / "series" / Path(area.id) / Path(thermal.name)
                 )
                 series_path = cluster_path / "series.txt"
                 os.makedirs(cluster_path, exist_ok=True)
@@ -941,7 +941,7 @@ class TestReadThermal:
                 _write_file(fuelCost_path, expected_time_serie)
 
                 cluster_path = (
-                    study_path / "input" / "thermal" / "prepro" / Path(area.id) / Path(thermal.properties.group.value)
+                    study_path / "input" / "thermal" / "prepro" / Path(area.id) / Path(thermal.name)
                 )
                 os.makedirs(cluster_path, exist_ok=True)
                 series_path_1 = cluster_path / "data.txt"


### PR DESCRIPTION

The name of the folder under area_id is properties.group.value, seems it is thermal.name instead