### PR TITLE
refactor(factory): move creation methods to implementation packages

### DIFF
--- a/src/antares/craft/__init__.py
+++ b/src/antares/craft/__init__.py
@@ -10,6 +10,87 @@
 #
 # This file is part of the Antares project.
 
-from antares.craft.model.study import create_study_api, create_study_local
+import typing
 
-__all__ = ["create_study_api", "create_study_local"]
+if typing.TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Optional
+
+from antares.craft.api_conf.api_conf import APIconf
+from antares.craft.model.study import Study
+
+__all__ = [
+    "Study",
+    "create_study_api",
+    "import_study_api",
+    "read_study_api",
+    "create_variant_api",
+    "read_study_local",
+    "create_study_local"
+]
+
+
+# Design note:
+# all following methods are entry points for study creation.
+# They use methods defined in "local" and "API" implementation services,
+# that we inject here.
+# Generally speaking, implementations should reference the API, not the
+# opposite. Here we perform dependency injection, and because of python
+# import mechanics, we need to use local imports to avoid circular dependencies.
+
+def create_study_local(study_name: str, version: str, parent_directory: "Path") -> "Study":
+    # Here we inject implementation of this method,
+    # we need to have a local import to avoid python circular dependency
+    from antares.craft.service.local_services.factory import create_study_local
+    return create_study_local(study_name, version, parent_directory)
+
+def read_study_local(study_path: "Path") -> "Study":
+    # Here we inject implementation of this method,
+    # we need to have a local import to avoid python circular dependency
+    from antares.craft.service.local_services.factory import read_study_local
+    return read_study_local(study_path)
+
+
+def create_study_api(
+    study_name: str,
+    version: str,
+    api_config: APIconf,
+    parent_path: "Optional[Path]" = None,
+) -> "Study":
+    """
+    Args:
+        study_name: antares study name to be created
+        version: antares version
+        api_config: host and token config for API
+
+    Raises:
+        MissingTokenError if api_token is missing
+        StudyCreationError if an HTTP Exception occurs
+    """
+    from antares.craft.service.api_services.factory import create_study_api
+    return create_study_api(study_name, version, api_config, parent_path)
+
+
+def import_study_api(api_config: APIconf, study_path: "Path", destination_path: "Optional[Path]" = None) -> "Study":
+    from antares.craft.service.api_services.factory import import_study_api
+    return import_study_api(api_config, study_path, destination_path)
+
+
+def read_study_api(api_config: APIconf, study_id: str) -> "Study":
+    from antares.craft.service.api_services.factory import read_study_api
+    return read_study_api(api_config, study_id)
+
+
+def create_variant_api(api_config: APIconf, study_id: str, variant_name: str) -> "Study":
+    """
+    Creates a variant from a study_id
+    Args:
+        api_config: API configuration
+        study_id: The id of the study to create a variant of
+        variant_name: the name of the new variant
+    Returns: The variant in the form of a Study object
+    """
+    from antares.craft.service.api_services.factory import create_variant_api
+    return create_variant_api(api_config, study_id, variant_name)
+
+

--- a/src/antares/craft/model/study.py
+++ b/src/antares/craft/model/study.py
@@ -9,10 +9,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-import io
-import logging
-import os
-import time
 
 from pathlib import Path, PurePath
 from types import MappingProxyType
@@ -20,15 +16,8 @@ from typing import List, Optional, cast
 
 import pandas as pd
 
-from antares.craft.api_conf.api_conf import APIconf
-from antares.craft.api_conf.request_wrapper import RequestWrapper
-from antares.craft.config.local_configuration import LocalConfiguration
 from antares.craft.exceptions.exceptions import (
-    APIError,
     LinkCreationError,
-    StudyCreationError,
-    StudyImportError,
-    StudyMoveError,
 )
 from antares.craft.model.area import Area, AreaProperties, AreaUi
 from antares.craft.model.binding_constraint import (
@@ -41,9 +30,7 @@ from antares.craft.model.output import Output
 from antares.craft.model.settings.study_settings import StudySettings, StudySettingsUpdate
 from antares.craft.model.simulation import AntaresSimulationParameters, Job
 from antares.craft.service.base_services import BaseLinkService, BaseStudyService
-from antares.craft.service.local_services.services.settings import edit_study_settings
 from antares.craft.service.service_factory import ServiceFactory
-from antares.craft.tools.ini_tool import IniFile, InitializationFilesTypes
 
 """
 The study module defines the data model for antares study.
@@ -52,201 +39,6 @@ between these areas.
 Optional attribute _api_id defined for studies being stored in web
 _study_path if stored in a disk
 """
-
-
-def create_study_api(
-    study_name: str,
-    version: str,
-    api_config: APIconf,
-    parent_path: Optional[Path] = None,
-) -> "Study":
-    """
-    Args:
-        study_name: antares study name to be created
-        version: antares version
-        api_config: host and token config for API
-
-    Raises:
-        MissingTokenError if api_token is missing
-        StudyCreationError if an HTTP Exception occurs
-    """
-
-    session = api_config.set_up_api_conf()
-    wrapper = RequestWrapper(session)
-    base_url = f"{api_config.get_host()}/api/v1"
-
-    try:
-        url = f"{base_url}/studies?name={study_name}&version={version}"
-        response = wrapper.post(url)
-        study_id = response.json()
-        # Settings part
-        study = Study(study_name, version, ServiceFactory(api_config, study_id))
-        study.read_settings()
-        # Move part
-        if parent_path:
-            study.move(parent_path)
-            url = f"{base_url}/studies/{study_id}"
-            json_study = wrapper.get(url).json()
-            folder = json_study.pop("folder")
-            study.path = PurePath(folder) if folder else PurePath(".")
-        return study
-    except (APIError, StudyMoveError) as e:
-        raise StudyCreationError(study_name, e.message) from e
-
-
-def import_study_api(api_config: APIconf, study_path: Path, destination_path: Optional[Path] = None) -> "Study":
-    session = api_config.set_up_api_conf()
-    wrapper = RequestWrapper(session)
-    base_url = f"{api_config.get_host()}/api/v1"
-
-    if study_path.suffix not in {".zip", ".7z"}:
-        raise StudyImportError(
-            study_path.name, f"File doesn't have the right extensions (.zip/.7z): {study_path.suffix}"
-        )
-
-    try:
-        files = {"study": io.BytesIO(study_path.read_bytes())}
-        url = f"{base_url}/studies/_import"
-        study_id = wrapper.post(url, files=files).json()
-
-        study = read_study_api(api_config, study_id)
-        if destination_path is not None:
-            study.move(destination_path)
-
-        return study
-    except APIError as e:
-        raise StudyImportError(study_path.name, e.message) from e
-
-
-def create_study_local(study_name: str, version: str, parent_directory: Path) -> "Study":
-    """
-    Create a directory structure for the study with empty files.
-
-    Args:
-        study_name: antares study name to be created
-        version: antares version for study
-        parent_directory: Local directory to store the study in.
-
-    Raises:
-        FileExistsError if the study already exists in the given location
-    """
-    local_config = LocalConfiguration(parent_directory, study_name)
-
-    study_directory = local_config.local_path / study_name
-
-    _verify_study_already_exists(study_directory)
-
-    # Create the directory structure
-    _create_directory_structure(study_directory)
-
-    # Create study.antares file with timestamps and study_name
-    antares_file_path = os.path.join(study_directory, "study.antares")
-    current_time = int(time.time())
-    antares_content = f"""[antares]
-version = {version}
-caption = {study_name}
-created = {current_time}
-lastsave = {current_time}
-author = Unknown
-"""
-    with open(antares_file_path, "w") as antares_file:
-        antares_file.write(antares_content)
-
-    # Create Desktop.ini file
-    desktop_ini_path = study_directory / "Desktop.ini"
-    desktop_ini_content = f"""[.ShellClassInfo]
-IconFile = settings/resources/study.ico
-IconIndex = 0
-InfoTip = Antares Study {version}: {study_name}
-"""
-    with open(desktop_ini_path, "w") as desktop_ini_file:
-        desktop_ini_file.write(desktop_ini_content)
-
-    # Create various .ini files for the study
-    _create_correlation_ini_files(study_directory)
-
-    logging.info(f"Study successfully created: {study_name}")
-    study = Study(
-        name=study_name,
-        version=version,
-        service_factory=ServiceFactory(config=local_config, study_name=study_name),
-        path=study_directory,
-    )
-    # We need to create the file with default value
-    default_settings = StudySettings()
-    update_settings = default_settings.to_update_settings()
-    edit_study_settings(study_directory, update_settings, True)
-    study._settings = default_settings
-    return study
-
-
-def read_study_local(study_directory: Path) -> "Study":
-    """
-    Read a study structure by returning a study object.
-    Args:
-        study_directory: antares study path to be read
-
-    Raises:
-        FileNotFoundError: If the provided directory does not exist.
-
-    """
-
-    def _directory_not_exists(local_path: Path) -> None:
-        if not local_path.is_dir():
-            raise FileNotFoundError(f"The path {local_path} doesn't exist or isn't a folder.")
-
-    _directory_not_exists(study_directory)
-
-    study_antares = IniFile(study_directory, InitializationFilesTypes.ANTARES)
-
-    study_params = study_antares.ini_dict["antares"]
-
-    local_config = LocalConfiguration(study_directory.parent, study_directory.name)
-
-    study = Study(
-        name=study_params["caption"],
-        version=study_params["version"],
-        service_factory=ServiceFactory(config=local_config, study_name=study_params["caption"]),
-        path=study_directory,
-    )
-    study.read_settings()
-    return study
-
-
-def read_study_api(api_config: APIconf, study_id: str) -> "Study":
-    session = api_config.set_up_api_conf()
-    wrapper = RequestWrapper(session)
-    base_url = f"{api_config.get_host()}/api/v1"
-    json_study = wrapper.get(f"{base_url}/studies/{study_id}").json()
-
-    study_name = json_study.pop("name")
-    study_version = str(json_study.pop("version"))
-    path = json_study.pop("folder")
-    pure_path = PurePath(path) if path else PurePath(".")
-
-    study = Study(study_name, study_version, ServiceFactory(api_config, study_id, study_name), pure_path)
-
-    study.read_settings()
-    study.read_areas()
-    study.read_outputs()
-    study.read_binding_constraints()
-
-    return study
-
-
-def create_variant_api(api_config: APIconf, study_id: str, variant_name: str) -> "Study":
-    """
-    Creates a variant from a study_id
-    Args:
-        api_config: API configuration
-        study_id: The id of the study to create a variant of
-        variant_name: the name of the new variant
-    Returns: The variant in the form of a Study object
-    """
-    factory = ServiceFactory(api_config, study_id)
-    api_service = factory.create_study_service()
-
-    return api_service.create_variant(variant_name)
 
 
 class Study:
@@ -472,50 +264,3 @@ class Study:
     def generate_thermal_timeseries(self) -> None:
         self._study_service.generate_thermal_timeseries()
 
-
-def _verify_study_already_exists(study_directory: Path) -> None:
-    if study_directory.exists():
-        raise FileExistsError(f"Study {study_directory.name} already exists.")
-
-
-def _create_directory_structure(study_path: Path) -> None:
-    subdirectories = [
-        "input/hydro/allocation",
-        "input/hydro/common/capacity",
-        "input/hydro/series",
-        "input/links",
-        "input/load/series",
-        "input/misc-gen",
-        "input/reserves",
-        "input/solar/series",
-        "input/thermal/clusters",
-        "input/thermal/prepro",
-        "input/thermal/series",
-        "input/wind/series",
-        "layers",
-        "output",
-        "settings/resources",
-        "settings/simulations",
-        "user",
-    ]
-    for subdirectory in subdirectories:
-        (study_path / subdirectory).mkdir(parents=True, exist_ok=True)
-
-
-def _create_correlation_ini_files(study_directory: Path) -> None:
-    correlation_inis_to_create = [
-        getattr(InitializationFilesTypes, field.upper() + "_CORRELATION_INI")
-        for field in ["hydro", "load", "solar", "wind"]
-    ]
-
-    ini_content = {"general": {"mode": "annual"}, "annual": {}}
-    for k in range(12):
-        ini_content[str(k)] = {}
-
-    for file_type in correlation_inis_to_create:
-        ini_file = IniFile(
-            study_directory,
-            file_type,
-            ini_contents=ini_content,
-        )
-        ini_file.write_ini_file()

--- a/src/antares/craft/service/api_services/factory.py
+++ b/src/antares/craft/service/api_services/factory.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+import io
+
+from pathlib import Path, PurePath
+from typing import Optional
+
+from antares.craft.api_conf.api_conf import APIconf
+from antares.craft.api_conf.request_wrapper import RequestWrapper
+from antares.craft.exceptions.exceptions import APIError, StudyCreationError, StudyImportError, StudyMoveError
+from antares.craft.model.study import Study
+from antares.craft.service.api_services.area_api import AreaApiService
+from antares.craft.service.api_services.binding_constraint_api import BindingConstraintApiService
+from antares.craft.service.api_services.link_api import LinkApiService
+from antares.craft.service.api_services.services.hydro import HydroApiService
+from antares.craft.service.api_services.services.output import OutputApiService
+from antares.craft.service.api_services.services.renewable import RenewableApiService
+from antares.craft.service.api_services.services.run import RunApiService
+from antares.craft.service.api_services.services.settings import StudySettingsAPIService
+from antares.craft.service.api_services.services.st_storage import ShortTermStorageApiService
+from antares.craft.service.api_services.services.thermal import ThermalApiService
+from antares.craft.service.api_services.study_api import StudyApiService
+from antares.craft.service.base_services import (
+    BaseAreaService,
+    BaseBindingConstraintService,
+    BaseHydroService,
+    BaseLinkService,
+    BaseOutputService,
+    BaseRenewableService,
+    BaseRunService,
+    BaseShortTermStorageService,
+    BaseStudyService,
+    BaseStudySettingsService,
+    BaseThermalService,
+)
+from antares.craft.service.service_factory import ServiceFactory
+from typing_extensions import override
+
+
+class ApiServiceFactory(ServiceFactory):
+    def __init__(self, config: APIconf, study_id: str = "", study_name: str = ""):
+        self.config = config
+        self.study_id = study_id
+        self.study_name = study_name
+
+    @override
+    def create_area_service(self) -> BaseAreaService:
+        # TODO: we should not have multiple instances of those services
+        storage_service: BaseShortTermStorageService = ShortTermStorageApiService(self.config, self.study_id)
+        thermal_service: BaseThermalService = ThermalApiService(self.config, self.study_id)
+        renewable_service: BaseRenewableService = RenewableApiService(self.config, self.study_id)
+        hydro_service: BaseHydroService = HydroApiService(self.config, self.study_id)
+        area_service: BaseAreaService = AreaApiService(
+            self.config, self.study_id, storage_service, thermal_service, renewable_service, hydro_service
+        )
+        return area_service
+
+    @override
+    def create_link_service(self) -> BaseLinkService:
+        return LinkApiService(self.config, self.study_id)
+
+    @override
+    def create_thermal_service(self) -> BaseThermalService:
+        return ThermalApiService(self.config, self.study_id)
+
+    @override
+    def create_binding_constraints_service(self) -> BaseBindingConstraintService:
+        return BindingConstraintApiService(self.config, self.study_id)
+
+    @override
+    def create_study_service(self) -> BaseStudyService:
+        output_service = self.create_output_service()
+        return StudyApiService(self.config, self.study_id, output_service)
+
+    @override
+    def create_renewable_service(self) -> BaseRenewableService:
+        return RenewableApiService(self.config, self.study_id)
+
+    @override
+    def create_st_storage_service(self) -> BaseShortTermStorageService:
+        return ShortTermStorageApiService(self.config, self.study_id)
+
+    @override
+    def create_run_service(self) -> BaseRunService:
+        return RunApiService(self.config, self.study_id)
+
+    @override
+    def create_output_service(self) -> BaseOutputService:
+        return OutputApiService(self.config, self.study_id)
+
+    @override
+    def create_settings_service(self) -> BaseStudySettingsService:
+        return StudySettingsAPIService(self.config, self.study_id)
+
+    @override
+    def create_hydro_service(self) -> BaseHydroService:
+        return HydroApiService(self.config, self.study_id)
+
+
+
+def create_study_api(
+    study_name: str,
+    version: str,
+    api_config: APIconf,
+    parent_path: Optional[Path] = None,
+) -> Study:
+    """
+    Args:
+        study_name: antares study name to be created
+        version: antares version
+        api_config: host and token config for API
+
+    Raises:
+        MissingTokenError if api_token is missing
+        StudyCreationError if an HTTP Exception occurs
+    """
+
+    session = api_config.set_up_api_conf()
+    wrapper = RequestWrapper(session)
+    base_url = f"{api_config.get_host()}/api/v1"
+
+    try:
+        url = f"{base_url}/studies?name={study_name}&version={version}"
+        response = wrapper.post(url)
+        study_id = response.json()
+        # Settings part
+        study = Study(study_name, version, ApiServiceFactory(api_config, study_id))
+        study.read_settings()
+        # Move part
+        if parent_path:
+            study.move(parent_path)
+            url = f"{base_url}/studies/{study_id}"
+            json_study = wrapper.get(url).json()
+            folder = json_study.pop("folder")
+            study.path = PurePath(folder) if folder else PurePath(".")
+        return study
+    except (APIError, StudyMoveError) as e:
+        raise StudyCreationError(study_name, e.message) from e
+
+
+def import_study_api(api_config: APIconf, study_path: Path, destination_path: Optional[Path] = None) -> "Study":
+    session = api_config.set_up_api_conf()
+    wrapper = RequestWrapper(session)
+    base_url = f"{api_config.get_host()}/api/v1"
+
+    if study_path.suffix not in {".zip", ".7z"}:
+        raise StudyImportError(
+            study_path.name, f"File doesn't have the right extensions (.zip/.7z): {study_path.suffix}"
+        )
+
+    try:
+        files = {"study": io.BytesIO(study_path.read_bytes())}
+        url = f"{base_url}/studies/_import"
+        study_id = wrapper.post(url, files=files).json()
+
+        study = read_study_api(api_config, study_id)
+        if destination_path is not None:
+            study.move(destination_path)
+
+        return study
+    except APIError as e:
+        raise StudyImportError(study_path.name, e.message) from e
+
+
+
+def read_study_api(api_config: APIconf, study_id: str) -> "Study":
+    session = api_config.set_up_api_conf()
+    wrapper = RequestWrapper(session)
+    base_url = f"{api_config.get_host()}/api/v1"
+    json_study = wrapper.get(f"{base_url}/studies/{study_id}").json()
+
+    study_name = json_study.pop("name")
+    study_version = str(json_study.pop("version"))
+    path = json_study.pop("folder")
+    pure_path = PurePath(path) if path else PurePath(".")
+
+    study = Study(study_name, study_version, ApiServiceFactory(api_config, study_id, study_name), pure_path)
+
+    study.read_settings()
+    study.read_areas()
+    study.read_outputs()
+    study.read_binding_constraints()
+
+    return study
+
+
+def create_variant_api(api_config: APIconf, study_id: str, variant_name: str) -> "Study":
+    """
+    Creates a variant from a study_id
+    Args:
+        api_config: API configuration
+        study_id: The id of the study to create a variant of
+        variant_name: the name of the new variant
+    Returns: The variant in the form of a Study object
+    """
+    factory = ApiServiceFactory(api_config, study_id)
+    api_service = factory.create_study_service()
+
+    return api_service.create_variant(variant_name)

--- a/src/antares/craft/service/api_services/study_api.py
+++ b/src/antares/craft/service/api_services/study_api.py
@@ -12,8 +12,6 @@
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING
 
-import antares.craft.model.study as study
-
 from antares.craft.api_conf.api_conf import APIconf
 from antares.craft.api_conf.request_wrapper import RequestWrapper
 from antares.craft.exceptions.exceptions import (
@@ -79,11 +77,12 @@ class StudyApiService(BaseStudyService):
 
     @override
     def create_variant(self, variant_name: str) -> "Study":
+        from antares.craft.service.api_services.factory import read_study_api
         url = f"{self._base_url}/studies/{self.study_id}/variants?name={variant_name}"
         try:
             response = self._wrapper.post(url)
             variant_id = response.json()
-            return study.read_study_api(self.config, variant_id)
+            return read_study_api(self.config, variant_id)
         except APIError as e:
             raise StudyVariantCreationError(self.study_id, e.message) from e
 

--- a/src/antares/craft/service/local_services/factory.py
+++ b/src/antares/craft/service/local_services/factory.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+import logging
+import os
+import time
+from pathlib import Path
+
+from typing_extensions import override
+
+from antares.craft.config.local_configuration import LocalConfiguration
+from antares.craft.model.settings.study_settings import StudySettings
+from antares.craft.model.study import Study
+from antares.craft.service.base_services import (
+    BaseAreaService,
+    BaseBindingConstraintService,
+    BaseHydroService,
+    BaseLinkService,
+    BaseOutputService,
+    BaseRenewableService,
+    BaseRunService,
+    BaseShortTermStorageService,
+    BaseStudyService,
+    BaseStudySettingsService,
+    BaseThermalService,
+)
+from antares.craft.service.local_services.area_local import AreaLocalService
+from antares.craft.service.local_services.binding_constraint_local import BindingConstraintLocalService
+from antares.craft.service.local_services.link_local import LinkLocalService
+from antares.craft.service.local_services.services.hydro import HydroLocalService
+from antares.craft.service.local_services.services.output import OutputLocalService
+from antares.craft.service.local_services.services.renewable import RenewableLocalService
+from antares.craft.service.local_services.services.run import RunLocalService
+from antares.craft.service.local_services.services.settings import StudySettingsLocalService, edit_study_settings
+from antares.craft.service.local_services.services.st_storage import ShortTermStorageLocalService
+from antares.craft.service.local_services.services.thermal import ThermalLocalService
+from antares.craft.service.local_services.study_local import StudyLocalService
+from antares.craft.service.service_factory import ServiceFactory
+from antares.craft.tools.ini_tool import IniFile, InitializationFilesTypes
+
+
+class LocalServiceFactory(ServiceFactory):
+    def __init__(self, config: LocalConfiguration, study_id: str = "", study_name: str = ""):
+        self.config = config
+        self.study_id = study_id
+        self.study_name = study_name
+
+    @override
+    def create_area_service(self) -> BaseAreaService:
+        # TODO: we should not have multiple instances of those services
+        storage_service = ShortTermStorageLocalService(self.config, self.study_name)
+        thermal_service = ThermalLocalService(self.config, self.study_name)
+        renewable_service = RenewableLocalService(self.config, self.study_name)
+        hydro_service = HydroLocalService(self.config, self.study_name)
+        area_service = AreaLocalService(
+            self.config, self.study_name, storage_service, thermal_service, renewable_service, hydro_service
+        )
+        return area_service
+
+    @override
+    def create_link_service(self) -> BaseLinkService:
+        return LinkLocalService(self.config, self.study_name)
+
+    @override
+    def create_thermal_service(self) -> BaseThermalService:
+        return ThermalLocalService(self.config, self.study_name)
+
+    @override
+    def create_binding_constraints_service(self) -> BaseBindingConstraintService:
+        return BindingConstraintLocalService(self.config, self.study_name)
+
+    @override
+    def create_study_service(self) -> BaseStudyService:
+        output_service = self.create_output_service()
+        study_service = StudyLocalService(self.config, self.study_name, output_service)
+        return study_service
+
+    @override
+    def create_renewable_service(self) -> BaseRenewableService:
+        return RenewableLocalService(self.config, self.study_name)
+
+    @override
+    def create_st_storage_service(self) -> BaseShortTermStorageService:
+        return ShortTermStorageLocalService(self.config, self.study_name)
+
+    @override
+    def create_run_service(self) -> BaseRunService:
+        return RunLocalService(self.config, self.study_name)
+
+    @override
+    def create_output_service(self) -> BaseOutputService:
+        return OutputLocalService(self.config, self.study_name)
+
+    @override
+    def create_settings_service(self) -> BaseStudySettingsService:
+        return StudySettingsLocalService(self.config, self.study_name)
+
+    @override
+    def create_hydro_service(self) -> BaseHydroService:
+        return HydroLocalService(self.config, self.study_name)
+
+
+
+def _create_correlation_ini_files(study_directory: Path) -> None:
+    correlation_inis_to_create = [
+        getattr(InitializationFilesTypes, field.upper() + "_CORRELATION_INI")
+        for field in ["hydro", "load", "solar", "wind"]
+    ]
+
+    ini_content = {"general": {"mode": "annual"}, "annual": {}}
+    for k in range(12):
+        ini_content[str(k)] = {}
+
+    for file_type in correlation_inis_to_create:
+        ini_file = IniFile(
+            study_directory,
+            file_type,
+            ini_contents=ini_content,
+        )
+        ini_file.write_ini_file()
+
+
+
+def _verify_study_already_exists(study_directory: Path) -> None:
+    if study_directory.exists():
+        raise FileExistsError(f"Study {study_directory.name} already exists.")
+
+
+def _create_directory_structure(study_path: Path) -> None:
+    subdirectories = [
+        "input/hydro/allocation",
+        "input/hydro/common/capacity",
+        "input/hydro/series",
+        "input/links",
+        "input/load/series",
+        "input/misc-gen",
+        "input/reserves",
+        "input/solar/series",
+        "input/thermal/clusters",
+        "input/thermal/prepro",
+        "input/thermal/series",
+        "input/wind/series",
+        "layers",
+        "output",
+        "settings/resources",
+        "settings/simulations",
+        "user",
+    ]
+    for subdirectory in subdirectories:
+        (study_path / subdirectory).mkdir(parents=True, exist_ok=True)
+
+def create_study_local(study_name: str, version: str, parent_directory: Path) -> "Study":
+    """
+    Create a directory structure for the study with empty files.
+
+    Args:
+        study_name: antares study name to be created
+        version: antares version for study
+        parent_directory: Local directory to store the study in.
+
+    Raises:
+        FileExistsError if the study already exists in the given location
+    """
+    local_config = LocalConfiguration(parent_directory, study_name)
+
+    study_directory = local_config.local_path / study_name
+
+    _verify_study_already_exists(study_directory)
+
+    # Create the directory structure
+    _create_directory_structure(study_directory)
+
+    # Create study.antares file with timestamps and study_name
+    antares_file_path = os.path.join(study_directory, "study.antares")
+    current_time = int(time.time())
+    antares_content = f"""[antares]
+version = {version}
+caption = {study_name}
+created = {current_time}
+lastsave = {current_time}
+author = Unknown
+"""
+    with open(antares_file_path, "w") as antares_file:
+        antares_file.write(antares_content)
+
+    # Create Desktop.ini file
+    desktop_ini_path = study_directory / "Desktop.ini"
+    desktop_ini_content = f"""[.ShellClassInfo]
+IconFile = settings/resources/study.ico
+IconIndex = 0
+InfoTip = Antares Study {version}: {study_name}
+"""
+    with open(desktop_ini_path, "w") as desktop_ini_file:
+        desktop_ini_file.write(desktop_ini_content)
+
+    # Create various .ini files for the study
+    _create_correlation_ini_files(study_directory)
+
+    logging.info(f"Study successfully created: {study_name}")
+    study = Study(
+        name=study_name,
+        version=version,
+        service_factory=LocalServiceFactory(config=local_config, study_name=study_name),
+        path=study_directory,
+    )
+    # We need to create the file with default value
+    default_settings = StudySettings()
+    update_settings = default_settings.to_update_settings()
+    edit_study_settings(study_directory, update_settings, True)
+    study._settings = default_settings
+    return study
+
+
+def read_study_local(study_directory: Path) -> "Study":
+    """
+    Read a study structure by returning a study object.
+    Args:
+        study_directory: antares study path to be read
+
+    Raises:
+        FileNotFoundError: If the provided directory does not exist.
+    """
+
+    def _directory_not_exists(local_path: Path) -> None:
+        if not local_path.is_dir():
+            raise FileNotFoundError(f"The path {local_path} doesn't exist or isn't a folder.")
+
+    _directory_not_exists(study_directory)
+
+    study_antares = IniFile(study_directory, InitializationFilesTypes.ANTARES)
+
+    study_params = study_antares.ini_dict["antares"]
+
+    local_config = LocalConfiguration(study_directory.parent, study_directory.name)
+
+    study = Study(
+        name=study_params["caption"],
+        version=study_params["version"],
+        service_factory=LocalServiceFactory(config=local_config, study_name=study_params["caption"]),
+        path=study_directory,
+    )
+    study.read_settings()
+    return study

--- a/src/antares/craft/service/local_services/study_local.py
+++ b/src/antares/craft/service/local_services/study_local.py
@@ -9,14 +9,22 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+import logging
+import os
+import time
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any
 
 from antares.craft.config.local_configuration import LocalConfiguration
 from antares.craft.model.binding_constraint import BindingConstraint
 from antares.craft.model.output import Output
+from antares.craft.model.settings.study_settings import StudySettings
 from antares.craft.service.base_services import BaseOutputService, BaseStudyService
 from typing_extensions import override
+
+from antares.craft.service.local_services.services.settings import edit_study_settings
+from antares.craft.service.service_factory import ServiceFactory
+from antares.craft.tools.ini_tool import InitializationFilesTypes, IniFile
 
 if TYPE_CHECKING:
     from antares.craft.model.study import Study

--- a/src/antares/craft/service/service_factory.py
+++ b/src/antares/craft/service/service_factory.py
@@ -9,21 +9,8 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+from abc import ABC, abstractmethod
 
-from antares.craft.api_conf.api_conf import APIconf
-from antares.craft.config.base_configuration import BaseConfiguration
-from antares.craft.config.local_configuration import LocalConfiguration
-from antares.craft.service.api_services.area_api import AreaApiService
-from antares.craft.service.api_services.binding_constraint_api import BindingConstraintApiService
-from antares.craft.service.api_services.link_api import LinkApiService
-from antares.craft.service.api_services.services.hydro import HydroApiService
-from antares.craft.service.api_services.services.output import OutputApiService
-from antares.craft.service.api_services.services.renewable import RenewableApiService
-from antares.craft.service.api_services.services.run import RunApiService
-from antares.craft.service.api_services.services.settings import StudySettingsAPIService
-from antares.craft.service.api_services.services.st_storage import ShortTermStorageApiService
-from antares.craft.service.api_services.services.thermal import ThermalApiService
-from antares.craft.service.api_services.study_api import StudyApiService
 from antares.craft.service.base_services import (
     BaseAreaService,
     BaseBindingConstraintService,
@@ -37,141 +24,58 @@ from antares.craft.service.base_services import (
     BaseStudySettingsService,
     BaseThermalService,
 )
-from antares.craft.service.local_services.area_local import AreaLocalService
-from antares.craft.service.local_services.binding_constraint_local import BindingConstraintLocalService
-from antares.craft.service.local_services.link_local import LinkLocalService
-from antares.craft.service.local_services.services.hydro import HydroLocalService
-from antares.craft.service.local_services.services.output import OutputLocalService
-from antares.craft.service.local_services.services.renewable import RenewableLocalService
-from antares.craft.service.local_services.services.run import RunLocalService
-from antares.craft.service.local_services.services.settings import StudySettingsLocalService
-from antares.craft.service.local_services.services.st_storage import ShortTermStorageLocalService
-from antares.craft.service.local_services.services.thermal import ThermalLocalService
-from antares.craft.service.local_services.study_local import StudyLocalService
 
 ERROR_MESSAGE = "Unsupported configuration type: "
 
 
-class ServiceFactory:
-    def __init__(self, config: BaseConfiguration, study_id: str = "", study_name: str = ""):
-        self.config = config
-        self.study_id = study_id
-        self.study_name = study_name
+class ServiceFactory(ABC):
+    """
+    Service factory API
+    """
 
+    @abstractmethod
     def create_area_service(self) -> BaseAreaService:
-        if isinstance(self.config, APIconf):
-            storage_service: BaseShortTermStorageService = ShortTermStorageApiService(self.config, self.study_id)
-            thermal_service: BaseThermalService = ThermalApiService(self.config, self.study_id)
-            renewable_service: BaseRenewableService = RenewableApiService(self.config, self.study_id)
-            hydro_service: BaseHydroService = HydroApiService(self.config, self.study_id)
-            area_service: BaseAreaService = AreaApiService(
-                self.config, self.study_id, storage_service, thermal_service, renewable_service, hydro_service
-            )
-        elif isinstance(self.config, LocalConfiguration):
-            storage_service = ShortTermStorageLocalService(self.config, self.study_name)
-            thermal_service = ThermalLocalService(self.config, self.study_name)
-            renewable_service = RenewableLocalService(self.config, self.study_name)
-            hydro_service = HydroLocalService(self.config, self.study_name)
-            area_service = AreaLocalService(
-                self.config, self.study_name, storage_service, thermal_service, renewable_service, hydro_service
-            )
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return area_service
+        ...
 
+    @abstractmethod
     def create_link_service(self) -> BaseLinkService:
-        if isinstance(self.config, APIconf):
-            link_service: BaseLinkService = LinkApiService(self.config, self.study_id)
-        elif isinstance(self.config, LocalConfiguration):
-            link_service = LinkLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return link_service
+        ...
 
+    @abstractmethod
     def create_thermal_service(self) -> BaseThermalService:
-        if isinstance(self.config, APIconf):
-            thermal_service: BaseThermalService = ThermalApiService(self.config, self.study_id)
-        elif isinstance(self.config, LocalConfiguration):
-            thermal_service = ThermalLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return thermal_service
+        ...
 
+    @abstractmethod
     def create_binding_constraints_service(self) -> BaseBindingConstraintService:
-        if isinstance(self.config, APIconf):
-            binding_constraint_service: BaseBindingConstraintService = BindingConstraintApiService(
-                self.config, self.study_id
-            )
-        elif isinstance(self.config, LocalConfiguration):
-            binding_constraint_service = BindingConstraintLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return binding_constraint_service
+        ...
 
+    @abstractmethod
     def create_study_service(self) -> BaseStudyService:
-        study_service: BaseStudyService
-        output_service = self.create_output_service()
-        if isinstance(self.config, APIconf):
-            study_service = StudyApiService(self.config, self.study_id, output_service)
-        elif isinstance(self.config, LocalConfiguration):
-            study_service = StudyLocalService(self.config, self.study_name, output_service)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
+        ...
 
-        return study_service
-
+    @abstractmethod
     def create_renewable_service(self) -> BaseRenewableService:
-        if isinstance(self.config, APIconf):
-            renewable_service: BaseRenewableService = RenewableApiService(self.config, self.study_id)
-        elif isinstance(self.config, LocalConfiguration):
-            renewable_service = RenewableLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return renewable_service
+        ...
 
+    @abstractmethod
     def create_st_storage_service(self) -> BaseShortTermStorageService:
-        if isinstance(self.config, APIconf):
-            short_term_storage_service: BaseShortTermStorageService = ShortTermStorageApiService(
-                self.config, self.study_id
-            )
-        elif isinstance(self.config, LocalConfiguration):
-            short_term_storage_service = ShortTermStorageLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return short_term_storage_service
+        ...
 
+    @abstractmethod
     def create_run_service(self) -> BaseRunService:
-        if isinstance(self.config, APIconf):
-            run_service: BaseRunService = RunApiService(self.config, self.study_id)
-        elif isinstance(self.config, LocalConfiguration):
-            run_service = RunLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return run_service
+        ...
 
+    @abstractmethod
     def create_output_service(self) -> BaseOutputService:
-        if isinstance(self.config, APIconf):
-            output_service: BaseOutputService = OutputApiService(self.config, self.study_id)
-        elif isinstance(self.config, LocalConfiguration):
-            output_service = OutputLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return output_service
+        ...
 
+    @abstractmethod
     def create_settings_service(self) -> BaseStudySettingsService:
-        if isinstance(self.config, APIconf):
-            settings_service: BaseStudySettingsService = StudySettingsAPIService(self.config, self.study_id)
-        elif isinstance(self.config, LocalConfiguration):
-            settings_service = StudySettingsLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return settings_service
+        ...
 
+    @abstractmethod
     def create_hydro_service(self) -> BaseHydroService:
-        if isinstance(self.config, APIconf):
-            hydro_service: BaseHydroService = HydroApiService(self.config, self.study_id)
-        elif isinstance(self.config, LocalConfiguration):
-            hydro_service = HydroLocalService(self.config, self.study_name)
-        else:
-            raise TypeError(f"{ERROR_MESSAGE}{repr(self.config)}")
-        return hydro_service
+        ...
+
+
+

--- a/tests/antares/integration/conftest.py
+++ b/tests/antares/integration/conftest.py
@@ -13,7 +13,7 @@
 import pytest
 
 from antares.craft.model.area import Area
-from antares.craft.model.study import Study, create_study_local
+from antares.craft import Study, create_study_local
 
 
 @pytest.fixture

--- a/tests/antares/integration/test_local_client.py
+++ b/tests/antares/integration/test_local_client.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from antares.craft import create_study_local
 from antares.craft.exceptions.exceptions import AreaCreationError, LinkCreationError
 from antares.craft.model.area import AdequacyPatchMode, Area, AreaProperties, AreaUi
 from antares.craft.model.binding_constraint import BindingConstraintProperties, ClusterData, ConstraintTerm, LinkData
@@ -29,7 +30,7 @@ from antares.craft.model.settings.advanced_parameters import (
 from antares.craft.model.settings.general import GeneralParametersUpdate
 from antares.craft.model.settings.study_settings import StudySettingsUpdate
 from antares.craft.model.st_storage import STStorageGroup, STStorageProperties
-from antares.craft.model.study import Study, create_study_local
+from antares.craft.model.study import Study
 from antares.craft.model.thermal import ThermalCluster, ThermalClusterGroup, ThermalClusterProperties
 from antares.craft.tools.ini_tool import IniFile, InitializationFilesTypes
 

--- a/tests/antares/services/api_services/test_area_api.py
+++ b/tests/antares/services/api_services/test_area_api.py
@@ -10,10 +10,9 @@
 #
 # This file is part of the Antares project.
 
+import pandas as pd
 import pytest
 import requests_mock
-
-import pandas as pd
 
 from antares.craft.api_conf.api_conf import APIconf
 from antares.craft.exceptions.exceptions import (
@@ -31,21 +30,21 @@ from antares.craft.model.st_storage import STStorage
 from antares.craft.model.study import Study
 from antares.craft.model.thermal import ThermalCluster, ThermalClusterProperties
 from antares.craft.service.api_services.area_api import AreaApiService
+from antares.craft.service.api_services.factory import ApiServiceFactory
 from antares.craft.service.api_services.models.hydro import HydroPropertiesAPI
 from antares.craft.service.api_services.models.renewable import RenewableClusterPropertiesAPI
 from antares.craft.service.api_services.models.st_storage import STStoragePropertiesAPI
 from antares.craft.service.api_services.models.thermal import ThermalClusterPropertiesAPI
-from antares.craft.service.service_factory import ServiceFactory
 
 
 class TestCreateAPI:
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
-    area_service = ServiceFactory(api, study_id).create_area_service()
-    st_storage_service = ServiceFactory(api, study_id).create_st_storage_service()
-    thermal_service = ServiceFactory(api, study_id).create_thermal_service()
-    renewable_service = ServiceFactory(api, study_id).create_renewable_service()
-    hydro_service = ServiceFactory(api, study_id).create_hydro_service()
+    area_service = ApiServiceFactory(api, study_id).create_area_service()
+    st_storage_service = ApiServiceFactory(api, study_id).create_st_storage_service()
+    thermal_service = ApiServiceFactory(api, study_id).create_thermal_service()
+    renewable_service = ApiServiceFactory(api, study_id).create_renewable_service()
+    hydro_service = ApiServiceFactory(api, study_id).create_hydro_service()
     area = Area("area_test", area_service, st_storage_service, thermal_service, renewable_service, hydro_service)
 
     area_api = AreaApiService(
@@ -58,7 +57,7 @@ class TestCreateAPI:
     )
     antares_web_description_msg = "Mocked Server KO"
     matrix = pd.DataFrame(data=[[1]])
-    study = Study("TestStudy", "880", ServiceFactory(api, study_id))
+    study = Study("TestStudy", "880", ApiServiceFactory(api, study_id))
 
     def test_update_area_properties_success(self):
         with requests_mock.Mocker() as mocker:

--- a/tests/antares/services/api_services/test_binding_constraint_api.py
+++ b/tests/antares/services/api_services/test_binding_constraint_api.py
@@ -20,6 +20,7 @@ from antares.craft.exceptions.exceptions import ConstraintMatrixDownloadError, C
 from antares.craft.model.area import Area
 from antares.craft.model.binding_constraint import BindingConstraint, BindingConstraintProperties, ConstraintMatrixName
 from antares.craft.model.study import Study
+from antares.craft.service.api_services.factory import ApiServiceFactory
 from antares.craft.service.service_factory import ServiceFactory
 
 
@@ -36,14 +37,15 @@ def constraint_set():
 class TestCreateAPI:
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
-    study = Study("study_test", "870", ServiceFactory(api, study_id))
+    factory = ApiServiceFactory(api, study_id)
+    study = Study("study_test", "870", factory)
     area = Area(
         "study_test",
-        ServiceFactory(api, study_id).create_area_service(),
-        ServiceFactory(api, study_id).create_st_storage_service(),
-        ServiceFactory(api, study_id).create_thermal_service(),
-        ServiceFactory(api, study_id).create_renewable_service(),
-        ServiceFactory(api, study_id).create_hydro_service(),
+        factory.create_area_service(),
+        factory.create_st_storage_service(),
+        factory.create_thermal_service(),
+        factory.create_renewable_service(),
+        factory.create_hydro_service(),
     )
     antares_web_description_msg = "Mocked Server KO"
     matrix = pd.DataFrame(data=[[0]])
@@ -52,7 +54,7 @@ class TestCreateAPI:
         with requests_mock.Mocker() as mocker:
             properties = BindingConstraintProperties(enabled=False)
             constraint = BindingConstraint(
-                "bc_1", ServiceFactory(self.api, self.study_id).create_binding_constraints_service()
+                "bc_1", ApiServiceFactory(self.api, self.study_id).create_binding_constraints_service()
             )
             url = f"https://antares.com/api/v1/studies/{self.study_id}/bindingconstraints/{constraint.id}"
             mocker.put(url, json={"id": "id", "name": "name", "terms": [], **properties.model_dump()}, status_code=200)
@@ -62,7 +64,7 @@ class TestCreateAPI:
         with requests_mock.Mocker() as mocker:
             properties = BindingConstraintProperties(enabled=False)
             constraint = BindingConstraint(
-                "bc_1", ServiceFactory(self.api, self.study_id).create_binding_constraints_service()
+                "bc_1", ApiServiceFactory(self.api, self.study_id).create_binding_constraints_service()
             )
             url = f"https://antares.com/api/v1/studies/{self.study_id}/bindingconstraints/{constraint.id}"
             antares_web_description_msg = "Server KO"
@@ -76,7 +78,7 @@ class TestCreateAPI:
 
     def test_get_constraint_matrix_success(self, constraint_set):
         constraint = BindingConstraint(
-            "bc_test", ServiceFactory(self.api, self.study_id).create_binding_constraints_service()
+            "bc_test", ApiServiceFactory(self.api, self.study_id).create_binding_constraints_service()
         )
         for matrix_method, enum_value, path, expected_matrix in constraint_set:
             with requests_mock.Mocker() as mocker:
@@ -87,7 +89,7 @@ class TestCreateAPI:
 
     def test_get_constraint_matrix_fails(self, constraint_set):
         constraint = BindingConstraint(
-            "bc_test", ServiceFactory(self.api, self.study_id).create_binding_constraints_service()
+            "bc_test", ApiServiceFactory(self.api, self.study_id).create_binding_constraints_service()
         )
         for matrix_method, enum_value, path, _ in constraint_set:
             with requests_mock.Mocker() as mocker:

--- a/tests/antares/services/api_services/test_link_api.py
+++ b/tests/antares/services/api_services/test_link_api.py
@@ -27,6 +27,7 @@ from antares.craft.model.area import Area
 from antares.craft.model.commons import FilterOption
 from antares.craft.model.link import Link, LinkProperties, LinkUi
 from antares.craft.model.study import Study
+from antares.craft.service.api_services.factory import ApiServiceFactory
 from antares.craft.service.service_factory import ServiceFactory
 
 
@@ -36,7 +37,8 @@ def expected_link():
     area_to_name = "zone4auto"
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
-    link_service = ServiceFactory(api, study_id).create_link_service()
+    factory = ApiServiceFactory(api, study_id)
+    link_service = factory.create_link_service()
     properties = {
         "hurdles-cost": False,
         "loop-flow": False,
@@ -65,7 +67,8 @@ def expected_link():
 class TestCreateAPI:
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
-    study = Study("study_test", "870", ServiceFactory(api, study_id))
+    factory = ApiServiceFactory(api, study_id)
+    study = Study("study_test", "870", factory)
     area_from = Area(
         name="area_from",
         area_service=api,
@@ -83,7 +86,7 @@ class TestCreateAPI:
         hydro_service=api,
     )
     antares_web_description_msg = "Mocked Server KO"
-    link = Link(area_from.id, area_to.id, ServiceFactory(api, study_id).create_link_service())
+    link = Link(area_from.id, area_to.id, factory.create_link_service())
     matrix = pd.DataFrame(data=[[0]])
 
     def test_update_links_properties_success(self):

--- a/tests/antares/services/api_services/test_matrix_api.py
+++ b/tests/antares/services/api_services/test_matrix_api.py
@@ -20,24 +20,26 @@ from antares.craft.api_conf.api_conf import APIconf
 from antares.craft.exceptions.exceptions import MatrixDownloadError, MatrixUploadError
 from antares.craft.model.area import Area
 from antares.craft.model.hydro import Hydro, HydroProperties
+from antares.craft.service.api_services.factory import ApiServiceFactory
 from antares.craft.service.service_factory import ServiceFactory
 
 
 class TestMatrixAPI:
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
+    factory = ApiServiceFactory(api, study_id)
     area = Area(
         "area_test",
-        ServiceFactory(api, study_id).create_area_service(),
-        ServiceFactory(api, study_id).create_st_storage_service(),
-        ServiceFactory(api, study_id).create_thermal_service(),
-        ServiceFactory(api, study_id).create_renewable_service(),
-        ServiceFactory(api, study_id).create_hydro_service(),
+        factory.create_area_service(),
+        factory.create_st_storage_service(),
+        factory.create_thermal_service(),
+        factory.create_renewable_service(),
+        factory.create_hydro_service(),
     )
 
     antares_web_description_msg = "Mocked Server KO"
     matrix = pd.DataFrame(data=[[0]])
-    hydro = Hydro(ServiceFactory(api, study_id).create_hydro_service(), "area_test", properties=HydroProperties())
+    hydro = Hydro(factory.create_hydro_service(), "area_test", properties=HydroProperties())
 
     # =======================
     #  LOAD

--- a/tests/antares/services/api_services/test_renewable_api.py
+++ b/tests/antares/services/api_services/test_renewable_api.py
@@ -25,6 +25,7 @@ from antares.craft.exceptions.exceptions import (
 from antares.craft.model.area import Area
 from antares.craft.model.renewable import RenewableCluster, RenewableClusterProperties, RenewableClusterPropertiesUpdate
 from antares.craft.service.api_services.area_api import AreaApiService
+from antares.craft.service.api_services.factory import ApiServiceFactory
 from antares.craft.service.api_services.models.renewable import RenewableClusterPropertiesAPI
 from antares.craft.service.api_services.services.renewable import RenewableApiService
 from antares.craft.service.service_factory import ServiceFactory
@@ -33,15 +34,16 @@ from antares.craft.service.service_factory import ServiceFactory
 class TestCreateAPI:
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
+    factory = ApiServiceFactory(api, study_id)
     area = Area(
         "study_test",
-        ServiceFactory(api, study_id).create_area_service(),
-        ServiceFactory(api, study_id).create_st_storage_service(),
-        ServiceFactory(api, study_id).create_thermal_service(),
-        ServiceFactory(api, study_id).create_renewable_service(),
-        ServiceFactory(api, study_id).create_hydro_service(),
+        factory.create_area_service(),
+        factory.create_st_storage_service(),
+        factory.create_thermal_service(),
+        factory.create_renewable_service(),
+        factory.create_hydro_service(),
     )
-    renewable = RenewableCluster(ServiceFactory(api, study_id).create_renewable_service(), area.id, "onshore_fr")
+    renewable = RenewableCluster(factory.create_renewable_service(), area.id, "onshore_fr")
     antares_web_description_msg = "Mocked Server KO"
     matrix = pd.DataFrame(data=[[0]])
 

--- a/tests/antares/services/api_services/test_st_storage_api.py
+++ b/tests/antares/services/api_services/test_st_storage_api.py
@@ -25,6 +25,7 @@ from antares.craft.exceptions.exceptions import (
 from antares.craft.model.area import Area
 from antares.craft.model.st_storage import STStorage, STStorageProperties
 from antares.craft.service.api_services.area_api import AreaApiService
+from antares.craft.service.api_services.factory import ApiServiceFactory
 from antares.craft.service.api_services.models.st_storage import STStoragePropertiesAPI
 from antares.craft.service.api_services.services.st_storage import ShortTermStorageApiService
 from antares.craft.service.service_factory import ServiceFactory
@@ -33,15 +34,16 @@ from antares.craft.service.service_factory import ServiceFactory
 class TestCreateAPI:
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
+    factory = ApiServiceFactory(api, study_id)
     area = Area(
         "study_test",
-        ServiceFactory(api, study_id).create_area_service(),
-        ServiceFactory(api, study_id).create_st_storage_service(),
-        ServiceFactory(api, study_id).create_thermal_service(),
-        ServiceFactory(api, study_id).create_renewable_service(),
-        ServiceFactory(api, study_id).create_hydro_service(),
+        factory.create_area_service(),
+        factory.create_st_storage_service(),
+        factory.create_thermal_service(),
+        factory.create_renewable_service(),
+        factory.create_hydro_service(),
     )
-    storage = STStorage(ServiceFactory(api, study_id).create_st_storage_service(), area.id, "battery_fr")
+    storage = STStorage(factory.create_st_storage_service(), area.id, "battery_fr")
     antares_web_description_msg = "Mocked Server KO"
     matrix = pd.DataFrame(data=[[0]])
 

--- a/tests/antares/services/api_services/test_study_api.py
+++ b/tests/antares/services/api_services/test_study_api.py
@@ -21,6 +21,7 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 
+from antares.craft import create_study_api, create_variant_api, import_study_api, read_study_api
 from antares.craft.api_conf.api_conf import APIconf
 from antares.craft.exceptions.exceptions import (
     AreaCreationError,
@@ -52,24 +53,25 @@ from antares.craft.model.output import (
 from antares.craft.model.settings.general import GeneralParametersUpdate, Mode
 from antares.craft.model.settings.study_settings import StudySettingsUpdate
 from antares.craft.model.simulation import AntaresSimulationParameters, Job, JobStatus, Solver
-from antares.craft.model.study import Study, create_study_api, create_variant_api, import_study_api, read_study_api
+from antares.craft.model.study import Study
+from antares.craft.service.api_services.factory import ApiServiceFactory
 from antares.craft.service.api_services.models.hydro import HydroPropertiesAPI
 from antares.craft.service.api_services.services.output import OutputApiService
-from antares.craft.service.service_factory import ServiceFactory
 
 
 class TestCreateAPI:
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
     antares_web_description_msg = "Mocked Server KO"
-    study = Study("TestStudy", "880", ServiceFactory(api, study_id))
+    factory = ApiServiceFactory(api, study_id)
+    study = Study("TestStudy", "880", factory)
     area = Area(
         "area_test",
-        ServiceFactory(api, study_id).create_area_service(),
-        ServiceFactory(api, study_id).create_st_storage_service(),
-        ServiceFactory(api, study_id).create_thermal_service(),
-        ServiceFactory(api, study_id).create_renewable_service(),
-        ServiceFactory(api, study_id).create_hydro_service(),
+        factory.create_area_service(),
+        factory.create_st_storage_service(),
+        factory.create_thermal_service(),
+        factory.create_renewable_service(),
+        factory.create_hydro_service(),
     )
 
     def test_create_study_test_ok(self) -> None:
@@ -272,7 +274,7 @@ class TestCreateAPI:
             expected_study = Study(
                 expected_study_name,
                 expected_study_version,
-                ServiceFactory(self.api, expected_study_id, expected_study_name),
+                ApiServiceFactory(self.api, expected_study_id, expected_study_name),
                 None,
             )
 

--- a/tests/antares/services/api_services/test_thermal_api.py
+++ b/tests/antares/services/api_services/test_thermal_api.py
@@ -9,12 +9,11 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-import pytest
-import requests_mock
-
 from unittest.mock import Mock
 
 import pandas as pd
+import pytest
+import requests_mock
 
 from antares.craft.api_conf.api_conf import APIconf
 from antares.craft.exceptions.exceptions import (
@@ -31,9 +30,9 @@ from antares.craft.model.thermal import (
     ThermalClusterPropertiesUpdate,
 )
 from antares.craft.service.api_services.area_api import AreaApiService
+from antares.craft.service.api_services.factory import ApiServiceFactory
 from antares.craft.service.api_services.models.thermal import ThermalClusterPropertiesAPI
 from antares.craft.service.api_services.services.thermal import ThermalApiService
-from antares.craft.service.service_factory import ServiceFactory
 
 
 @pytest.fixture
@@ -51,16 +50,17 @@ def thermal_matrix_set():
 class TestCreateAPI:
     api = APIconf("https://antares.com", "token", verify=False)
     study_id = "22c52f44-4c2a-407b-862b-490887f93dd8"
-    study = Study("study_test", "870", ServiceFactory(api, study_id))
+    factory = ApiServiceFactory(api, study_id)
+    study = Study("study_test", "870", factory)
     area = Area(
         "area-test",
-        ServiceFactory(api, study_id).create_area_service(),
-        ServiceFactory(api, study_id).create_st_storage_service(),
-        ServiceFactory(api, study_id).create_thermal_service(),
-        ServiceFactory(api, study_id).create_renewable_service(),
-        ServiceFactory(api, study_id).create_hydro_service(),
+        factory.create_area_service(),
+        factory.create_st_storage_service(),
+        factory.create_thermal_service(),
+        factory.create_renewable_service(),
+        factory.create_hydro_service(),
     )
-    thermal = ThermalCluster(ServiceFactory(api, study_id).create_thermal_service(), "area-test", "thermal-test")
+    thermal = ThermalCluster(factory.create_thermal_service(), "area-test", "thermal-test")
     antares_web_description_msg = "Mocked Server KO"
     matrix = pd.DataFrame(data=[[0]])
 

--- a/tests/antares/services/local_services/conftest.py
+++ b/tests/antares/services/local_services/conftest.py
@@ -13,6 +13,7 @@ import pytest
 
 import pandas as pd
 
+from antares.craft import create_study_local
 from antares.craft.model.area import Area, AreaPropertiesLocal
 from antares.craft.model.binding_constraint import (
     BindingConstraint,
@@ -23,7 +24,7 @@ from antares.craft.model.binding_constraint import (
 from antares.craft.model.hydro import HydroProperties, HydroPropertiesUpdate
 from antares.craft.model.renewable import RenewableClusterGroup, RenewableClusterProperties, TimeSeriesInterpretation
 from antares.craft.model.st_storage import STStorageGroup, STStorageProperties
-from antares.craft.model.study import Study, create_study_local
+from antares.craft.model.study import Study
 from antares.craft.model.thermal import (
     LawOption,
     LocalTSGenerationBehavior,

--- a/tests/antares/services/local_services/test_area.py
+++ b/tests/antares/services/local_services/test_area.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from antares.craft import read_study_local
 from antares.craft.config.local_configuration import LocalConfiguration
 from antares.craft.model.renewable import (
     RenewableCluster,
@@ -30,7 +31,6 @@ from antares.craft.model.renewable import (
     TimeSeriesInterpretation,
 )
 from antares.craft.model.st_storage import STStorage, STStorageGroup, STStorageProperties
-from antares.craft.model.study import read_study_local
 from antares.craft.model.thermal import ThermalCluster
 from antares.craft.tools.ini_tool import IniFile, InitializationFilesTypes
 from antares.craft.tools.matrix_tool import df_save

--- a/tests/antares/services/local_services/test_study.py
+++ b/tests/antares/services/local_services/test_study.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from antares.craft import create_study_local
 from antares.craft.config.local_configuration import LocalConfiguration
 from antares.craft.exceptions.exceptions import (
     AreaCreationError,
@@ -81,7 +82,6 @@ from antares.craft.model.settings.optimization import (
 )
 from antares.craft.model.settings.study_settings import StudySettings
 from antares.craft.model.settings.thematic_trimming import ThematicTrimmingParameters
-from antares.craft.model.study import create_study_local
 from antares.craft.tools.ini_tool import InitializationFilesTypes
 
 

--- a/tests/antares/services/local_services/test_study_read.py
+++ b/tests/antares/services/local_services/test_study_read.py
@@ -16,7 +16,7 @@ import re
 
 from pathlib import Path
 
-from antares.craft.model.study import read_study_local
+from antares.craft import read_study_local
 
 
 class TestReadStudy:

--- a/tests/integration/test_web_client.py
+++ b/tests/integration/test_web_client.py
@@ -18,6 +18,7 @@ from pathlib import Path, PurePath
 import numpy as np
 import pandas as pd
 
+from antares.craft import create_study_api, create_variant_api, import_study_api, read_study_api
 from antares.craft.api_conf.api_conf import APIconf
 from antares.craft.exceptions.exceptions import (
     AreaDeletionError,
@@ -59,7 +60,6 @@ from antares.craft.model.st_storage import (
     STStorageProperties,
     STStoragePropertiesUpdate,
 )
-from antares.craft.model.study import create_study_api, create_variant_api, import_study_api, read_study_api
 from antares.craft.model.thermal import ThermalClusterGroup, ThermalClusterProperties, ThermalClusterPropertiesUpdate
 
 from tests.integration.antares_web_desktop import AntaresWebDesktop


### PR DESCRIPTION
Also:
- separates service factory in 2 implementations
- exports creation methods in antares.craft top level module