### PR TITLE
Fixes/ matrix tool and area local service

### DIFF
--- a/src/antares/craft/service/local_services/services/area.py
+++ b/src/antares/craft/service/local_services/services/area.py
@@ -155,9 +155,8 @@ class AreaLocalService(BaseAreaService):
         list_ini = IniFile(self.config.study_path, InitializationFilesTypes.RENEWABLES_LIST_INI, area_id=area_id)
         list_ini.add_section({renewable_name: new_section_content})
         list_ini.write_ini_file()
-
-        if series:
-            write_timeseries(self.config.study_path, series, TimeSeriesFileType.RENEWABLE_DATA_SERIES, area_id)
+        if isinstance(series, pd.DataFrame) and not series.empty:
+            write_timeseries(self.config.study_path, series, TimeSeriesFileType.RENEWABLE_DATA_SERIES, area_id, cluster_id=transform_name_to_id(renewable_name))
 
         return RenewableCluster(self.renewable_service, area_id, renewable_name, properties)
 

--- a/src/antares/craft/tools/matrix_tool.py
+++ b/src/antares/craft/tools/matrix_tool.py
@@ -65,6 +65,13 @@ def read_timeseries(
     return _time_series
 
 
-def write_timeseries(study_path: Path, series: pd.DataFrame, ts_file_type: TimeSeriesFileType, area_id: str) -> None:
-    file_path = study_path.joinpath(ts_file_type.value.format(area_id=area_id))
+def write_timeseries(study_path: Path, series: pd.DataFrame, ts_file_type: TimeSeriesFileType, area_id: str, cluster_id: Optional[str] = None, second_area_id: Optional[str] = None) -> None:
+    if second_area_id:
+        file_path = study_path.joinpath(ts_file_type.value.format(area_id=area_id, second_area_id=second_area_id))
+    elif cluster_id:
+        file_path = study_path.joinpath(ts_file_type.value.format(area_id=area_id, cluster_id=cluster_id))
+    else:
+        file_path = study_path.joinpath(ts_file_type.value.format(area_id=area_id))
+    if not file_path.parent.is_dir():
+        file_path.parent.mkdir(parents=True)
     series.to_csv(file_path, sep="\t", header=False, index=False, encoding="utf-8")


### PR DESCRIPTION
- write_timeseries  now can be used to create series for path that have 2 patterns to match, and even if the path folders are missing
- series variable, if it is a dataframe, is not a condition enough accurate to know if it is empty or not