### PR TITLE
Accept native bools for ExportMPS enum class

### DIFF
--- a/src/antares/craft/model/settings/optimization.py
+++ b/src/antares/craft/model/settings/optimization.py
@@ -35,8 +35,8 @@ class SimplexOptimizationRange(Enum):
 
 
 class ExportMPS(Enum):
-    TRUE = "True"
-    FALSE = "False"
+    TRUE = True
+    FALSE = False
     OPTIM1 = "optim1"
     OPTIM2 = "optim2"
 

--- a/tests/antares/services/local_services/test_exportmps.py
+++ b/tests/antares/services/local_services/test_exportmps.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+import pytest
+
+from antares.craft.model.settings.optimization import ExportMPS
+
+def test_exportmps_conversion_bool():
+    assert ExportMPS.TRUE == ExportMPS(True)
+    assert ExportMPS.FALSE == ExportMPS(False)
+
+def test_exportmps_conversion_string():
+    assert ExportMPS.OPTIM1 == ExportMPS("optim1")
+    assert ExportMPS.OPTIM2 == ExportMPS("optim2")

--- a/tests/antares/services/local_services/test_exportmps.py
+++ b/tests/antares/services/local_services/test_exportmps.py
@@ -20,3 +20,8 @@ def test_exportmps_conversion_bool():
 def test_exportmps_conversion_string():
     assert ExportMPS.OPTIM1 == ExportMPS("optim1")
     assert ExportMPS.OPTIM2 == ExportMPS("optim2")
+# These are no longer supported
+    with pytest.raises(ValueError):
+        ExportMPS("True")
+    with pytest.raises(ValueError):
+        ExportMPS("False")


### PR DESCRIPTION
It becomes possible to write
```py
craft.ExportMPS(True)
craft.ExportMPS(False)
```
instead of
```
craft.ExportMPS("True")
craft.ExportMPS("False")
```

I added some unit tests to check the associated behavior.