### PR TITLE
fix(local, sts): additional constraints were saved in a wrong format

### DIFF
--- a/src/antares/craft/service/local_services/services/st_storage.py
+++ b/src/antares/craft/service/local_services/services/st_storage.py
@@ -211,7 +211,7 @@ class ShortTermStorageLocalService(BaseShortTermStorageService):
             # Round trip for validation
             saved_constraints[constraint.id] = parse_st_storage_constraint_local(content)
 
-            content.pop("name", None) # AW doesn't take name in the INI file
+            content.pop("name", None)  # AW doesn't take name in the INI file
             ini_content[constraint.name] = content
 
         # Save the data in the ini file

--- a/src/antares/craft/service/local_services/services/st_storage.py
+++ b/src/antares/craft/service/local_services/services/st_storage.py
@@ -208,9 +208,11 @@ class ShortTermStorageLocalService(BaseShortTermStorageService):
         ini_content = {}
         for constraint in constraints.values():
             content = serialize_st_storage_constraint_local(constraint)
-            ini_content[constraint.name] = content
             # Round trip for validation
             saved_constraints[constraint.id] = parse_st_storage_constraint_local(content)
+
+            content.pop("name", None) # AW doesn't take name in the INI file
+            ini_content[constraint.name] = content
 
         # Save the data in the ini file
         self._save_ini_constraints(ini_content, area_id, storage_id)

--- a/src/antares/craft/service/local_services/services/st_storage.py
+++ b/src/antares/craft/service/local_services/services/st_storage.py
@@ -211,7 +211,7 @@ class ShortTermStorageLocalService(BaseShortTermStorageService):
             # Round trip for validation
             saved_constraints[constraint.id] = parse_st_storage_constraint_local(content)
 
-            content.pop("name", None)  # AW doesn't take name in the INI file
+            content.pop("name", None)
             ini_content[constraint.name] = content
 
         # Save the data in the ini file

--- a/tests/antares/services/local_services/test_st_storage.py
+++ b/tests/antares/services/local_services/test_st_storage.py
@@ -336,14 +336,12 @@ def test_nominal_case_additional_constraints(local_study_92: Study) -> None:
         "Constraint2??": {
             "enabled": True,
             "hours": "[167, 168]",
-            "name": "Constraint2??",
             "operator": "greater",
             "variable": "netting",
         },
         "constraint_1": {
             "enabled": False,
             "hours": "[]",
-            "name": "constraint_1",
             "operator": "less",
             "variable": "netting",
         },
@@ -362,7 +360,6 @@ def test_nominal_case_additional_constraints(local_study_92: Study) -> None:
         "Constraint2??": {
             "enabled": True,
             "hours": "[167, 168]",
-            "name": "Constraint2??",
             "operator": "greater",
             "variable": "netting",
         }


### PR DESCRIPTION
Fix following a pydantic validation error because of a model mismatch (`STStorageAdditionalConstraintFileData` in AW doesn't contain `name` but it's written in the `.ini` file)
