### PR TITLE
Add local study validation API

### DIFF
--- a/src/antares/craft/__init__.py
+++ b/src/antares/craft/__init__.py
@@ -97,6 +97,7 @@ from antares.craft.model.study import (
     import_study_api,
     read_study_api,
     read_study_local,
+    validate_study_local,
 )
 from antares.craft.model.thermal import (
     LawOption,
@@ -127,6 +128,7 @@ __all__ = [
     "read_study_api",
     "create_variant_api",
     "read_study_local",
+    "validate_study_local",
     "create_study_local",
     # Enums
     "PriceTakingOrder",

--- a/src/antares/craft/model/study.py
+++ b/src/antares/craft/model/study.py
@@ -16,6 +16,8 @@ from typing import Dict, List, Optional, cast
 
 import pandas as pd
 
+from antares.study.version import StudyVersion
+
 from antares.craft import (
     APIconf,
     PlaylistParameters,
@@ -49,7 +51,6 @@ from antares.craft.model.st_storage import STStorage
 from antares.craft.model.thermal import ThermalCluster, ThermalClusterPropertiesUpdate
 from antares.craft.model.xpansion.xpansion_configuration import XpansionConfiguration
 from antares.craft.service.base_services import BaseLinkService, BaseStudyService, StudyServices
-from antares.study.version import StudyVersion
 
 """
 The study module defines the data model for Antares studies.
@@ -622,6 +623,21 @@ def read_study_local(study_path: Path | str) -> "Study":
     from antares.craft.service.local_services.factory import read_study_local
 
     return read_study_local(study_path)
+
+
+def validate_study_local(study_path: Path | str) -> bool:
+    """
+    Checks whether an existing study on your filesystem can be read.
+
+    Parameters:
+        study_path: the path to the existing study on your filesystem
+
+    Returns:
+        True if the study can be read, False otherwise
+    """
+    from antares.craft.service.local_services.factory import validate_study_local
+
+    return validate_study_local(study_path)
 
 
 def create_study_api(study_name: str, version: str, api_config: APIconf, parent_path: Path | None = None) -> "Study":

--- a/src/antares/craft/service/local_services/factory.py
+++ b/src/antares/craft/service/local_services/factory.py
@@ -14,6 +14,9 @@ import getpass
 from pathlib import Path
 from typing import Any, cast
 
+from antares.study.version import StudyVersion
+from antares.study.version.create_app import CreateApp
+
 from antares.craft import HydroProperties
 from antares.craft.config.local_configuration import LocalConfiguration
 from antares.craft.model.area import Area
@@ -60,8 +63,6 @@ from antares.craft.service.local_services.services.thermal import ThermalLocalSe
 from antares.craft.service.local_services.services.xpansion import XpansionLocalService
 from antares.craft.tools.contents_tool import transform_name_to_id
 from antares.craft.tools.serde_local.ini_reader import IniReader
-from antares.study.version import StudyVersion
-from antares.study.version.create_app import CreateApp
 
 
 def create_local_services(config: LocalConfiguration, study_name: str, study_version: StudyVersion) -> StudyServices:
@@ -151,6 +152,21 @@ def create_study_local(study_name: str, version: str, parent_directory: Path | s
     study._settings.adequacy_patch_parameters = parse_adequacy_parameters_local(study_version, {})
 
     return study
+
+
+def validate_study_local(study_directory: Path | str) -> bool:
+    """Return whether the provided path points to a readable local study."""
+    try:
+        if isinstance(study_directory, str):
+            study_directory = Path(study_directory)
+        if not study_directory.is_dir():
+            return False
+        study_antares_path = study_directory / "study.antares"
+        study_params = IniReader().read(study_antares_path)["antares"]
+        StudyVersion.parse(str(study_params["version"]))
+    except Exception:
+        return False
+    return True
 
 
 def read_study_local(study_directory: Path | str) -> "Study":


### PR DESCRIPTION
Adds a lightweight `validate_study_local` entry point that checks whether a local study path has the expected directory and readable `study.antares` metadata without loading the full study object. This lets callers quickly skip invalid study paths while keeping the existing `read_study_local` behavior unchanged.

Verification: `python3 -m compileall -q src/antares/craft/service/local_services/factory.py src/antares/craft/model/study.py src/antares/craft/__init__.py`; smoke check with `create_study_local` and `validate_study_local`; `python3 -m pytest tests/antares/services/local_services/test_study_read.py -q`; `ruff check src/antares/craft/service/local_services/factory.py src/antares/craft/model/study.py src/antares/craft/__init__.py`; `git diff --check`.
