### PR TITLE
fix(local): add check to forbid duplication on various objects

### DIFF
--- a/src/antares/craft/model/study.py
+++ b/src/antares/craft/model/study.py
@@ -28,6 +28,7 @@ from antares.craft.exceptions.exceptions import (
     LinkCreationError,
     ReferencedObjectDeletionNotAllowed,
     UnsupportedStudyVersion,
+    XpansionConfigurationCreationError,
     XpansionConfigurationMissingError,
 )
 from antares.craft.model.area import Area, AreaProperties, AreaPropertiesUpdate, AreaUi
@@ -567,6 +568,11 @@ class Study:
         Returns:
             Default xpansion configuration.
         """
+        if self.has_an_xpansion_configuration:
+            raise XpansionConfigurationCreationError(
+                self._study_service.study_id, "Xpansion configuration already exists"
+            )
+
         configuration = self._xpansion_service.create_xpansion_configuration()
         self._xpansion_configuration = configuration
         return configuration

--- a/src/antares/craft/service/local_services/services/area.py
+++ b/src/antares/craft/service/local_services/services/area.py
@@ -27,6 +27,7 @@ from antares.craft.config.local_configuration import LocalConfiguration
 from antares.craft.exceptions.exceptions import (
     AreaCreationError,
     ReferencedObjectDeletionNotAllowed,
+    RenewableCreationError,
     STStorageCreationError,
     ThermalCreationError,
 )
@@ -204,6 +205,15 @@ class AreaLocalService(BaseAreaService):
         local_renewable_service = cast(RenewableLocalService, self.renewable_service)
         local_renewable_service.read_ini(area_id)
         ini_content = local_renewable_service.read_ini(area_id)
+
+        # Checks for duplication
+        renewable_id = transform_name_to_id(renewable_name)
+        existing_ids = {transform_name_to_id(key) for key in ini_content}
+        if renewable_id in existing_ids:
+            raise RenewableCreationError(
+                renewable_name, area_id, f"Renewable cluster '{renewable_name}' already exists in area '{area_id}'."
+            )
+
         content = serialize_renewable_cluster_local(self.study_version, properties or RenewableClusterProperties())
         ini_content[renewable_name] = {"name": renewable_name, **content}
         local_renewable_service.save_ini(ini_content, area_id)

--- a/src/antares/craft/service/local_services/services/area.py
+++ b/src/antares/craft/service/local_services/services/area.py
@@ -27,6 +27,7 @@ from antares.craft.config.local_configuration import LocalConfiguration
 from antares.craft.exceptions.exceptions import (
     AreaCreationError,
     ReferencedObjectDeletionNotAllowed,
+    STStorageCreationError,
     ThermalCreationError,
 )
 from antares.craft.model.area import (
@@ -234,6 +235,14 @@ class AreaLocalService(BaseAreaService):
 
         local_storage_service = cast(ShortTermStorageLocalService, self.storage_service)
         ini_content = local_storage_service.read_ini(area_id)
+
+        # Checks for duplication
+        sts_id = transform_name_to_id(st_storage_name)
+        existing_ids = {transform_name_to_id(key) for key in ini_content}
+        if sts_id in existing_ids:
+            raise STStorageCreationError(
+                st_storage_name, area_id, f"St-storage '{st_storage_name}' already exists in area '{area_id}'."
+            )
 
         ini_content[st_storage_name] = {
             "name": st_storage_name,

--- a/tests/antares/services/local_services/test_renewable.py
+++ b/tests/antares/services/local_services/test_renewable.py
@@ -21,7 +21,11 @@ import pandas as pd
 from checksumdir import dirhash
 
 from antares.craft import RenewableClusterGroup, Study, TimeSeriesInterpretation, read_study_local
-from antares.craft.exceptions.exceptions import MatrixFormatError, RenewablePropertiesUpdateError
+from antares.craft.exceptions.exceptions import (
+    MatrixFormatError,
+    RenewableCreationError,
+    RenewablePropertiesUpdateError,
+)
 from antares.craft.model.renewable import RenewableClusterProperties, RenewableClusterPropertiesUpdate
 from antares.craft.tools.serde_local.ini_reader import IniReader
 from antares.craft.tools.serde_local.ini_writer import IniWriter
@@ -160,3 +164,14 @@ class TestRenewable:
         # Ensures before version 9.3, using a free group is possible but it will be considered as `OTHER 1`.
         renewable = local_study_92.get_areas()["fr"].create_renewable_cluster("ren2", properties=props)
         assert renewable.properties.group == "other res 1"
+
+    def test_create_renewable_cluster_that_already_exists(self, local_study_92: Study) -> None:
+        area = local_study_92.get_areas()["fr"]
+
+        cluster_name = "Renew test"
+        area.create_renewable_cluster(cluster_name)
+
+        with pytest.raises(
+            RenewableCreationError, match=re.escape(f"Renewable cluster '{cluster_name}' already exists in area")
+        ):
+            area.create_renewable_cluster(cluster_name)

--- a/tests/antares/services/local_services/test_st_storage.py
+++ b/tests/antares/services/local_services/test_st_storage.py
@@ -25,6 +25,7 @@ from antares.craft import STStorageAdditionalConstraintUpdate, STStorageGroup, S
 from antares.craft.exceptions.exceptions import (
     InvalidFieldForVersionError,
     MatrixFormatError,
+    STStorageCreationError,
     STStoragePropertiesUpdateError,
 )
 from antares.craft.model.commons import STUDY_VERSION_8_8, STUDY_VERSION_9_2
@@ -278,6 +279,14 @@ class TestSTStorage:
         storage.set_storage_inflows(inflows)  # Should succeed
 
         pd.testing.assert_frame_equal(storage.get_storage_inflows(), inflows, check_dtype=False)
+
+    def test_create_storage_that_already_exists(self, local_study_92: Study) -> None:
+        area = local_study_92.get_areas()["fr"]
+
+        area.create_st_storage("sts")
+
+        with pytest.raises(STStorageCreationError, match=re.escape("St-storage 'sts' already exists in area")):
+            area.create_st_storage("sts")
 
 
 ##########################

--- a/tests/antares/services/local_services/test_xpansion.py
+++ b/tests/antares/services/local_services/test_xpansion.py
@@ -32,6 +32,7 @@ from antares.craft.exceptions.exceptions import (
     XpansionCandidateCoherenceError,
     XpansionCandidateDeletionError,
     XpansionCandidateEditionError,
+    XpansionConfigurationCreationError,
     XpansionConstraintsDeletionError,
     XpansionConstraintsEditionError,
     XpansionFileDeletionError,
@@ -612,3 +613,9 @@ class TestXpansion:
         file_path.write_text("{}")
         study = read_study_local(Path(study.path))
         assert study.xpansion.sensitivity == XpansionSensitivity(epsilon=0, projection=[], capex=False)
+
+    def test_forbid_configuration_creation_when_already_present(self, local_study: Study) -> None:
+        local_study.create_xpansion_configuration()
+
+        with pytest.raises(XpansionConfigurationCreationError, match="Xpansion configuration already exists"):
+            local_study.create_xpansion_configuration()


### PR DESCRIPTION
Forbid object creation when they already existed in the study for the following objects:
- Short term storages
- Renewable clusters
- Xpansion configuration